### PR TITLE
ci: add GitHub Actions for CI and automated publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,10 @@ jobs:
           pip install ".[test]"
 
       - name: Run tests
+        run: pytest -v
+
+      - name: Run tests with coverage
+        if: matrix.python-version == '3.12'
         run: pytest --cov=acedatacloud --cov-report=xml -v
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,131 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  python-lint:
+    name: Python Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[dev]"
+
+      - name: Run Ruff linter
+        run: ruff check .
+
+      - name: Run Ruff formatter check
+        run: ruff format --check .
+
+  python-test:
+    name: Python Test (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[test]"
+
+      - name: Run tests
+        run: pytest --cov=acedatacloud --cov-report=xml -v
+
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v5
+        with:
+          files: python/coverage.xml
+          fail_ci_if_error: false
+
+  typescript-lint:
+    name: TypeScript Lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  python-build:
+    name: Python Build
+    runs-on: ubuntu-latest
+    needs: [python-lint, python-test]
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+  typescript-build:
+    name: TypeScript Build
+    runs-on: ubuntu-latest
+    needs: [typescript-lint]
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -1,0 +1,154 @@
+name: Publish Python SDK
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "python/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate date-based version
+        id: version
+        run: |
+          DATE_PREFIX=$(date +'%Y.%-m.%-d')
+          pip install requests -q
+          LATEST_BUILD=$(python -c "
+          import requests
+          try:
+              resp = requests.get('https://pypi.org/pypi/acedatacloud/json', timeout=10)
+              if resp.status_code == 200:
+                  versions = resp.json().get('releases', {}).keys()
+                  today_prefix = '${DATE_PREFIX}'
+                  today_versions = [v for v in versions if v.startswith(today_prefix)]
+                  if today_versions:
+                      builds = []
+                      for v in today_versions:
+                          parts = v.split('.')
+                          if len(parts) == 4:
+                              builds.append(int(parts[3]))
+                      print(max(builds) + 1 if builds else 0)
+                  else:
+                      print(0)
+              else:
+                  print(0)
+          except:
+              print(0)
+          ")
+          VERSION="${DATE_PREFIX}.${LATEST_BUILD}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          python -c "
+          import re
+          with open('pyproject.toml', 'r') as f:
+              content = f.read()
+          content = re.sub(r'version = \"[^\"]+\"', f'version = \"$VERSION\"', content, count=1)
+          with open('pyproject.toml', 'w') as f:
+              f.write(content)
+          "
+          echo "Updated pyproject.toml to version $VERSION"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-package-distributions
+          path: python/dist/
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[test]"
+
+      - name: Run tests
+        run: pytest -v
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/acedatacloud/${{ needs.build.outputs.version }}
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip install "twine>=5.0.0,<6.0.0"
+          twine upload dist/*
+
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    needs: [build, publish-pypi]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "python-v${{ needs.build.outputs.version }}" dist/* \
+            --title "Python SDK v${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            --repo '${{ github.repository }}' || echo "Release already exists, skipping"

--- a/.github/workflows/publish-typescript.yaml
+++ b/.github/workflows/publish-typescript.yaml
@@ -1,0 +1,165 @@
+name: Publish TypeScript SDK
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "typescript/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Generate date-based version
+        id: version
+        run: |
+          DATE_PREFIX=$(date +'%Y.%-m.%-d')
+          LATEST_BUILD=$(node -e "
+            const https = require('https');
+            https.get('https://registry.npmjs.org/@acedatacloud/sdk', (res) => {
+              let body = '';
+              res.on('data', d => body += d);
+              res.on('end', () => {
+                try {
+                  const data = JSON.parse(body);
+                  const versions = Object.keys(data.versions || {});
+                  const todayPrefix = '${DATE_PREFIX}';
+                  const todayVersions = versions.filter(v => v.startsWith(todayPrefix));
+                  if (todayVersions.length === 0) { console.log(0); return; }
+                  const builds = todayVersions.map(v => {
+                    const parts = v.split('.');
+                    return parts.length === 4 ? parseInt(parts[3]) : 0;
+                  });
+                  console.log(Math.max(...builds) + 1);
+                } catch(e) { console.log(0); }
+              });
+            }).on('error', () => console.log(0));
+          ")
+          VERSION="${DATE_PREFIX}.${LATEST_BUILD}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Generated version: $VERSION"
+
+      - name: Update version in package.json
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          echo "Updated package.json to version $VERSION"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: typescript-package
+          path: |
+            typescript/dist/
+            typescript/package.json
+            typescript/README.md
+
+  lint:
+    name: Type Check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  publish-npm:
+    name: Publish to npm
+    needs: [build, lint]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@acedatacloud/sdk
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Update version in package.json
+        run: |
+          VERSION="${{ needs.build.outputs.version }}"
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  create-release:
+    name: Create GitHub Release
+    if: github.event_name == 'push'
+    needs: [build, publish-npm]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "typescript-v${{ needs.build.outputs.version }}" \
+            --title "TypeScript SDK v${{ needs.build.outputs.version }}" \
+            --generate-notes \
+            --repo '${{ github.repository }}' || echo "Release already exists, skipping"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,7 @@ test = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "respx>=0.21",
+    "pytest-cov>=4.0",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,12 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
     "respx>=0.21",
+    "ruff>=0.4.0",
+]
+test = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "respx>=0.21",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -30,3 +36,6 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 120
 target-version = "py39"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "B", "C4", "UP"]

--- a/python/src/acedatacloud/_client.py
+++ b/python/src/acedatacloud/_client.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from typing import Any
 
 from acedatacloud._runtime.transport import AsyncTransport, SyncTransport
-from acedatacloud.resources.chat import AsyncChat, Chat
-from acedatacloud.resources.images import AsyncImages, Images
 from acedatacloud.resources.audio import AsyncAudio, Audio
-from acedatacloud.resources.video import AsyncVideo, Video
+from acedatacloud.resources.chat import AsyncChat, Chat
+from acedatacloud.resources.files import AsyncFiles, Files
+from acedatacloud.resources.images import AsyncImages, Images
+from acedatacloud.resources.openai_compat import AsyncOpenAI, OpenAI
+from acedatacloud.resources.platform import AsyncPlatform, Platform
 from acedatacloud.resources.search import AsyncSearch, Search
 from acedatacloud.resources.tasks import AsyncTasks, Tasks
-from acedatacloud.resources.files import AsyncFiles, Files
-from acedatacloud.resources.platform import AsyncPlatform, Platform
-from acedatacloud.resources.openai_compat import AsyncOpenAI, OpenAI
+from acedatacloud.resources.video import AsyncVideo, Video
 
 _API_BASE = "https://api.acedata.cloud"
 _PLATFORM_BASE = "https://platform.acedata.cloud"

--- a/python/src/acedatacloud/_runtime/tasks.py
+++ b/python/src/acedatacloud/_runtime/tasks.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import time
 import asyncio
+import time
 from typing import Any
 
 

--- a/python/src/acedatacloud/_runtime/transport.py
+++ b/python/src/acedatacloud/_runtime/transport.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import os
-import time
 import random
-from typing import Any, Iterator
+import time
+from collections.abc import Iterator
+from typing import Any
 
 import httpx
 
@@ -248,7 +249,6 @@ class AsyncTransport:
         max_retries: int,
         extra_headers: dict[str, str],
     ) -> None:
-        import asyncio
 
         token = api_token or os.environ.get("ACEDATACLOUD_API_TOKEN", "")
         if not token:

--- a/python/src/acedatacloud/resources/chat.py
+++ b/python/src/acedatacloud/resources/chat.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json as _json
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 
 class _Messages:

--- a/python/src/acedatacloud/resources/openai_compat.py
+++ b/python/src/acedatacloud/resources/openai_compat.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json as _json
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
 
 class _Completions:

--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -1,7 +1,5 @@
 """Tests for AceDataCloud Python SDK."""
 
-import json
-
 import httpx
 import pytest
 import respx
@@ -66,9 +64,7 @@ def test_openai_responses(client):
         "id": "resp-123",
         "output": [{"type": "message", "content": [{"type": "output_text", "text": "Hi there"}]}],
     }
-    respx.post("https://api.acedata.cloud/openai/responses").mock(
-        return_value=httpx.Response(200, json=mock_response)
-    )
+    respx.post("https://api.acedata.cloud/openai/responses").mock(return_value=httpx.Response(200, json=mock_response))
 
     result = client.openai.responses.create(
         model="gpt-4o",
@@ -89,9 +85,7 @@ def test_chat_messages(client):
         "content": [{"type": "text", "text": "Hi!"}],
         "usage": {"input_tokens": 10, "output_tokens": 5},
     }
-    respx.post("https://api.acedata.cloud/v1/messages").mock(
-        return_value=httpx.Response(200, json=mock_response)
-    )
+    respx.post("https://api.acedata.cloud/v1/messages").mock(return_value=httpx.Response(200, json=mock_response))
 
     result = client.chat.messages.create(
         model="claude-sonnet-4-20250514",
@@ -143,9 +137,7 @@ def test_audio_generate(client):
         "task_id": "task-audio",
         "data": [{"title": "My Song", "audio_url": "https://cdn.acedata.cloud/song.mp3"}],
     }
-    respx.post("https://api.acedata.cloud/suno/audios").mock(
-        return_value=httpx.Response(200, json=mock_response)
-    )
+    respx.post("https://api.acedata.cloud/suno/audios").mock(return_value=httpx.Response(200, json=mock_response))
 
     result = client.audio.generate(prompt="A happy song")
     assert result["data"][0]["title"] == "My Song"
@@ -161,9 +153,7 @@ def test_video_generate(client):
         "task_id": "task-video",
         "data": [{"video_url": "https://cdn.acedata.cloud/video.mp4"}],
     }
-    respx.post("https://api.acedata.cloud/sora/videos").mock(
-        return_value=httpx.Response(200, json=mock_response)
-    )
+    respx.post("https://api.acedata.cloud/sora/videos").mock(return_value=httpx.Response(200, json=mock_response))
 
     result = client.video.generate(prompt="A sunset timelapse")
     assert result["data"][0]["video_url"] == "https://cdn.acedata.cloud/video.mp4"
@@ -175,13 +165,9 @@ def test_video_generate(client):
 @respx.mock
 def test_search_google(client):
     mock_response = {
-        "organic": [
-            {"title": "Example", "link": "https://example.com", "snippet": "An example", "position": 1}
-        ],
+        "organic": [{"title": "Example", "link": "https://example.com", "snippet": "An example", "position": 1}],
     }
-    respx.post("https://api.acedata.cloud/serp/google").mock(
-        return_value=httpx.Response(200, json=mock_response)
-    )
+    respx.post("https://api.acedata.cloud/serp/google").mock(return_value=httpx.Response(200, json=mock_response))
 
     result = client.search.google(query="example")
     assert result["organic"][0]["title"] == "Example"
@@ -196,9 +182,7 @@ def test_tasks_get(client):
         "id": "task-abc",
         "response": {"status": "succeeded", "data": [{"image_url": "https://cdn.acedata.cloud/ok.png"}]},
     }
-    respx.post("https://api.acedata.cloud/nano-banana/tasks").mock(
-        return_value=httpx.Response(200, json=mock_response)
-    )
+    respx.post("https://api.acedata.cloud/nano-banana/tasks").mock(return_value=httpx.Response(200, json=mock_response))
 
     result = client.tasks.get("task-abc", service="nano-banana")
     assert result["response"]["status"] == "succeeded"
@@ -210,9 +194,7 @@ def test_tasks_get(client):
 @respx.mock
 def test_platform_applications_list(client):
     mock = {"count": 1, "results": [{"id": "app-1", "service_id": "svc-1"}]}
-    respx.get("https://platform.acedata.cloud/api/v1/applications/").mock(
-        return_value=httpx.Response(200, json=mock)
-    )
+    respx.get("https://platform.acedata.cloud/api/v1/applications/").mock(return_value=httpx.Response(200, json=mock))
     result = client.platform.applications.list()
     assert result["count"] == 1
 
@@ -220,9 +202,7 @@ def test_platform_applications_list(client):
 @respx.mock
 def test_platform_credentials_list(client):
     mock = {"count": 1, "results": [{"id": "cred-1", "token": "platform-abc"}]}
-    respx.get("https://platform.acedata.cloud/api/v1/credentials/").mock(
-        return_value=httpx.Response(200, json=mock)
-    )
+    respx.get("https://platform.acedata.cloud/api/v1/credentials/").mock(return_value=httpx.Response(200, json=mock))
     result = client.platform.credentials.list()
     assert result["results"][0]["token"] == "platform-abc"
 
@@ -240,9 +220,7 @@ def test_platform_credentials_rotate(client):
 @respx.mock
 def test_platform_models_list(client):
     mock = {"data": [{"id": "claude-sonnet-4-20250514", "owned_by": "anthropic"}]}
-    respx.get("https://platform.acedata.cloud/api/v1/models/").mock(
-        return_value=httpx.Response(200, json=mock)
-    )
+    respx.get("https://platform.acedata.cloud/api/v1/models/").mock(return_value=httpx.Response(200, json=mock))
     result = client.platform.models.list()
     assert result["data"][0]["id"] == "claude-sonnet-4-20250514"
 
@@ -250,9 +228,7 @@ def test_platform_models_list(client):
 @respx.mock
 def test_platform_config_get(client):
     mock = {"features": {"DISCOUNT_FOR_X402": 0.9}}
-    respx.get("https://platform.acedata.cloud/api/v1/config/").mock(
-        return_value=httpx.Response(200, json=mock)
-    )
+    respx.get("https://platform.acedata.cloud/api/v1/config/").mock(return_value=httpx.Response(200, json=mock))
     result = client.platform.config.get()
     assert result["features"]["DISCOUNT_FOR_X402"] == 0.9
 
@@ -268,9 +244,7 @@ def test_auth_error(client):
         )
     )
     with pytest.raises(AuthenticationError) as exc_info:
-        client.openai.chat.completions.create(
-            model="test", messages=[{"role": "user", "content": "hi"}]
-        )
+        client.openai.chat.completions.create(model="test", messages=[{"role": "user", "content": "hi"}])
     assert exc_info.value.status_code == 401
     assert exc_info.value.trace_id == "t-1"
 
@@ -283,9 +257,7 @@ def test_balance_error(client):
         )
     )
     with pytest.raises(InsufficientBalanceError):
-        client.openai.chat.completions.create(
-            model="test", messages=[{"role": "user", "content": "hi"}]
-        )
+        client.openai.chat.completions.create(model="test", messages=[{"role": "user", "content": "hi"}])
 
 
 @respx.mock
@@ -296,9 +268,7 @@ def test_rate_limit_error(client):
         )
     )
     with pytest.raises(RateLimitError):
-        client.openai.chat.completions.create(
-            model="test", messages=[{"role": "user", "content": "hi"}]
-        )
+        client.openai.chat.completions.create(model="test", messages=[{"role": "user", "content": "hi"}])
 
 
 @respx.mock
@@ -309,9 +279,7 @@ def test_validation_error(client):
         )
     )
     with pytest.raises(ValidationError):
-        client.openai.chat.completions.create(
-            model="bad", messages=[{"role": "user", "content": "hi"}]
-        )
+        client.openai.chat.completions.create(model="bad", messages=[{"role": "user", "content": "hi"}])
 
 
 # ── Async Tests ───────────────────────────────────────────────────────
@@ -341,9 +309,7 @@ async def test_async_openai_completions(async_client):
 @pytest.mark.asyncio
 async def test_async_search(async_client):
     mock_response = {"organic": [{"title": "Async Example", "link": "https://example.com"}]}
-    respx.post("https://api.acedata.cloud/serp/google").mock(
-        return_value=httpx.Response(200, json=mock_response)
-    )
+    respx.post("https://api.acedata.cloud/serp/google").mock(return_value=httpx.Response(200, json=mock_response))
 
     result = await async_client.search.google(query="async test")
     assert result["organic"][0]["title"] == "Async Example"


### PR DESCRIPTION
Add CI/CD workflows for automated testing and publishing.

## Workflows

- **CI** (ci.yaml): Push/PR to main — ruff lint + format check, pytest (Python 3.10/3.11/3.12 matrix), tsc type-check, build verification
- **Publish Python** (publish-python.yaml): Push to main (python/ changes) — CalVer versioning, build, publish to PyPI (acedatacloud), GitHub Release
- **Publish TypeScript** (publish-typescript.yaml): Push to main (typescript/ changes) — CalVer versioning, build, publish to npm (@acedatacloud/sdk), GitHub Release

## Versioning

Both use CalVer YYYY.M.D.BUILD — auto-increments build counter per day by querying the respective registry (PyPI / npm).

## Required Secrets

- `PYPI_TOKEN` — PyPI API token for acedatacloud package
- `NPM_TOKEN` — npm access token for @acedatacloud/sdk package

## Also in this PR

- Fix ruff lint issues (import sorting, unused imports, typing modernization)
- Add ruff lint config and test optional-dependency group to pyproject.toml
