### PR TITLE
fix(ci): upgrade twine for Metadata-Version 2.4 support

### DIFF
--- a/.github/workflows/publish-python.yaml
+++ b/.github/workflows/publish-python.yaml
@@ -125,7 +125,7 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          pip install "twine>=5.0.0,<6.0.0"
+          pip install "twine>=6.0.0"
           twine upload dist/*
 
   create-release:


### PR DESCRIPTION
hatchling generates Metadata-Version 2.4 which twine 5.x rejects with 'Metadata is missing required fields'. Upgrade to twine >=6.0.0 which supports the newer metadata version.