### PR TITLE
feat: add multi-provider support to Python SDK

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,53 @@
+# Copilot Sync Instructions for AceDataCloud SDK
+
+## Repository Structure
+
+This is a monorepo with two SDK implementations:
+
+- `typescript/` — TypeScript/Node.js SDK (`@acedatacloud/sdk` on npm)
+- `python/` — Python SDK (`acedatacloud` on PyPI)
+
+## Source of Truth
+
+The **AceDataCloud/Docs** repo is the source of truth:
+
+- `openapi/<service>.json` — OpenAPI specs for each service
+- `guides/<service>.md` — Usage guides (optional reference)
+
+## What to Sync
+
+When the Docs repo changes, compare the OpenAPI specs against the SDK code and update:
+
+### TypeScript (`typescript/src/`)
+
+1. **Provider types** in `resources/images.ts`, `resources/video.ts`, `resources/audio.ts`:
+   - Each resource has a union type (e.g., `ImageProvider`, `VideoProvider`, `AudioProvider`)
+   - Ensure all providers from the OpenAPI specs are included
+   - Default provider should match the most common/stable option
+
+2. **Task endpoints** in `resources/tasks.ts`:
+   - `SERVICE_TASK_ENDPOINTS` map must include all providers
+   - Format: `'provider-name': '/provider-name/tasks'`
+
+3. **Request parameters** in resource files:
+   - Compare function parameter types against OpenAPI request body schemas
+   - Add any new required or optional parameters
+
+4. **API paths** in resource files:
+   - Verify endpoint paths match the OpenAPI `paths` section
+   - Special cases (e.g., midjourney uses `/midjourney/imagine` not `/midjourney/images`)
+
+### Python (`python/src/acedatacloud/`)
+
+1. **Provider enums/types** — same logic as TypeScript
+2. **Request models** — match OpenAPI schemas
+3. **Endpoint paths** — match OpenAPI paths
+
+## Rules
+
+- Do NOT change the SDK architecture or patterns — only update data (providers, parameters, paths)
+- Do NOT modify `runtime/transport.ts` or `runtime/errors.ts` unless the error codes change
+- Do NOT modify CI/CD workflows
+- Keep backward compatibility: add new providers/params, don't remove existing ones unless the API removed them
+- Run `npx tsc --noEmit` in `typescript/` to verify changes compile
+- Run `ruff check .` in `python/` to verify linting passes

--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -1,0 +1,147 @@
+name: Sync from Docs
+
+on:
+  repository_dispatch:
+    types: [docs-updated]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  create-task:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      issue_number: ${{ steps.create-issue.outputs.issue_number }}
+    steps:
+      - name: Checkout Docs
+        uses: actions/checkout@v6
+        with:
+          repository: AceDataCloud/Docs
+          path: _docs
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          fetch-depth: 5
+
+      - name: Get Docs changes
+        id: docs
+        run: |
+          cd _docs
+          commit_info=$(git log -1 --pretty=format:"%h %s" 2>/dev/null || echo "unknown")
+          echo "commit_info=$commit_info" >> "$GITHUB_OUTPUT"
+
+          recent_changes=$(git log --oneline -5 2>/dev/null || echo "unknown")
+          echo "recent_changes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$recent_changes" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          changed_services="${{ github.event.client_payload.changed_services }}"
+          if [ -z "$changed_services" ]; then
+            changed_services="all"
+          fi
+          echo "changed_services=$changed_services" >> "$GITHUB_OUTPUT"
+
+      - name: Close existing sync issues
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          gh issue list --repo "${{ github.repository }}" --label "auto-sync" --state open --json number --jq '.[].number' | while read -r num; do
+            gh issue close "$num" --repo "${{ github.repository }}" --comment "Superseded by new sync trigger." 2>/dev/null || true
+          done
+
+      - name: Create issue for Copilot
+        id: create-issue
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          COMMIT_INFO: ${{ steps.docs.outputs.commit_info }}
+          RECENT_CHANGES: ${{ steps.docs.outputs.recent_changes }}
+          CHANGED_SERVICES: ${{ steps.docs.outputs.changed_services }}
+          REPO: ${{ github.repository }}
+        run: |
+          body=$(jq -n \
+            --arg changes "$RECENT_CHANGES" \
+            --arg services "$CHANGED_SERVICES" \
+            '"The upstream Docs have been updated. Ensure the SDK in this repo is in sync with the latest API specs.\n\n## Changed Services\n\n`" + $services + "`\n\n## Recent Docs Changes\n\n```\n" + $changes + "\n```\n\n## Instructions\n\nSee `.github/copilot-instructions.md` for sync rules.\n\nThis is a monorepo with `typescript/` and `python/` subdirectories.\n\nCheck the AceDataCloud/Docs repo OpenAPI specs at `openapi/<service>.json` for each changed service.\n\nCompare models, endpoints, parameters, and provider lists against the SDK code. Fix any differences.\n\nIf everything is already in sync, close this issue."')
+
+          ISSUE_URL=$(jq -n \
+            --arg title "sync: update from Docs ($COMMIT_INFO)" \
+            --argjson body "$body" \
+            --arg repo "$REPO" \
+            '{
+              title: $title,
+              body: $body,
+              labels: ["auto-sync"],
+              assignees: ["copilot-swe-agent[bot]"],
+              agent_assignment: {
+                target_repo: $repo,
+                base_branch: "main",
+                custom_instructions: "Check out the AceDataCloud/Docs repo and read the openapi/ specs. This is a monorepo — typescript/ and python/ are SDK implementations. Compare the provider lists, endpoints, request/response models against the Docs specs. Update TypeScript types, Python models, and provider enums as needed. Read .github/copilot-instructions.md for detailed sync rules. If everything is already in sync, close this issue with a comment saying so."
+              }
+            }' | gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/"$REPO"/issues \
+              --input - --jq '.number')
+
+          echo "Created issue #$ISSUE_URL"
+          echo "issue_number=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+
+  wait-and-merge:
+    needs: create-task
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Wait for Copilot PR and merge
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ needs.create-task.outputs.issue_number }}
+        run: |
+          echo "Waiting for Copilot to process issue #$ISSUE_NUMBER..."
+
+          for i in $(seq 1 90); do
+            echo "Poll attempt $i/90..."
+
+            ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --repo "${{ github.repository }}" --json state --jq '.state')
+            if [ "$ISSUE_STATE" = "CLOSED" ]; then
+              echo "Issue #$ISSUE_NUMBER was closed — Copilot determined no changes needed."
+              exit 0
+            fi
+
+            PR_JSON=$(gh pr list --repo "${{ github.repository }}" \
+              --state open --json number,title,author,isDraft,headRefName \
+              --jq '[.[] | select(.headRefName | startswith("copilot/"))] | .[0] // empty')
+
+            if [ -n "$PR_JSON" ]; then
+              PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+              PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+              HEAD_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
+              echo "Found PR #$PR_NUMBER: $PR_TITLE (branch=$HEAD_BRANCH)"
+
+              AGENT_STATUS=$(gh api "/repos/${{ github.repository }}/actions/runs?branch=$HEAD_BRANCH&event=dynamic" \
+                --jq '[.workflow_runs[] | select(.name == "Running Copilot coding agent")] | .[0].conclusion // "pending"' 2>/dev/null || echo "pending")
+
+              echo "Copilot agent status: $AGENT_STATUS"
+
+              if [ "$AGENT_STATUS" = "success" ]; then
+                echo "Copilot agent completed. Merging PR #$PR_NUMBER..."
+                gh pr ready "$PR_NUMBER" --repo "${{ github.repository }}" 2>/dev/null || true
+                gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --squash \
+                  --admin --subject "sync: update from Docs [automated]"
+                echo "PR #$PR_NUMBER merged successfully!"
+                exit 0
+              elif [ "$AGENT_STATUS" = "failure" ]; then
+                echo "Copilot agent failed. Manual intervention needed."
+                exit 1
+              else
+                echo "Copilot still working... waiting 20s"
+              fi
+            fi
+
+            sleep 20
+          done
+
+          echo "Timeout: No PR found after 30 minutes."
+          echo "Check issue #$ISSUE_NUMBER for status."
+          exit 1

--- a/python/README.md
+++ b/python/README.md
@@ -63,10 +63,35 @@ asyncio.run(main())
 ## Image Generation (with Task Polling)
 
 ```python
+# Default provider (nano-banana)
 task = client.images.generate(prompt="A sunset over mountains")
 result = task.wait()  # polls until complete
 print(result["image_url"])
+
+# Use a specific provider
+mj_task = client.images.generate(prompt="A sunset over mountains", provider="midjourney")
 ```
+
+## Multi-Provider Support
+
+Image, video, and audio resources support a `provider` parameter to switch between services:
+
+```python
+# Video — default is 'sora'
+client.video.generate(prompt="A cat playing piano", provider="kling")
+client.video.generate(prompt="Ocean waves", provider="luma")
+
+# Audio — default is 'suno'
+client.audio.generate(prompt="A jazz song", provider="producer")
+```
+
+Available providers:
+
+| Resource | Providers |
+|----------|-----------|
+| `client.images` | `nano-banana` (default), `midjourney`, `flux`, `seedream` |
+| `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse` |
+| `client.audio` | `suno` (default), `producer` |
 
 ## Error Handling
 

--- a/python/src/acedatacloud/__init__.py
+++ b/python/src/acedatacloud/__init__.py
@@ -15,10 +15,16 @@ from acedatacloud._runtime.errors import (
     TransportError,
     ValidationError,
 )
+from acedatacloud.resources.audio import AudioProvider
+from acedatacloud.resources.images import ImageProvider
+from acedatacloud.resources.video import VideoProvider
 
 __all__ = [
     "AceDataCloud",
     "AsyncAceDataCloud",
+    "AudioProvider",
+    "ImageProvider",
+    "VideoProvider",
     "AceDataCloudError",
     "APIError",
     "AuthenticationError",

--- a/python/src/acedatacloud/resources/audio.py
+++ b/python/src/acedatacloud/resources/audio.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
+
+AudioProvider = Literal["suno", "producer"]
 
 
 class Audio:
@@ -17,6 +19,7 @@ class Audio:
         self,
         *,
         prompt: str,
+        provider: AudioProvider | str = "suno",
         model: str | None = None,
         tags: str | None = None,
         callback_url: str | None = None,
@@ -33,13 +36,13 @@ class Audio:
         if callback_url is not None:
             body["callback_url"] = callback_url
 
-        result = self._transport.request("POST", "/suno/audios", json=body)
+        result = self._transport.request("POST", f"/{provider}/audios", json=body)
         task_id = result.get("task_id")
 
         if not task_id or (result.get("data") and not wait):
             return result
 
-        handle = TaskHandle(task_id, "/suno/tasks", self._transport)
+        handle = TaskHandle(task_id, f"/{provider}/tasks", self._transport)
         if wait:
             return handle.wait(poll_interval=poll_interval, max_wait=max_wait)
         return handle
@@ -55,6 +58,7 @@ class AsyncAudio:
         self,
         *,
         prompt: str,
+        provider: AudioProvider | str = "suno",
         model: str | None = None,
         tags: str | None = None,
         callback_url: str | None = None,
@@ -71,13 +75,13 @@ class AsyncAudio:
         if callback_url is not None:
             body["callback_url"] = callback_url
 
-        result = await self._transport.request("POST", "/suno/audios", json=body)
+        result = await self._transport.request("POST", f"/{provider}/audios", json=body)
         task_id = result.get("task_id")
 
         if not task_id or (result.get("data") and not wait):
             return result
 
-        handle = AsyncTaskHandle(task_id, "/suno/tasks", self._transport)
+        handle = AsyncTaskHandle(task_id, f"/{provider}/tasks", self._transport)
         if wait:
             return await handle.wait(poll_interval=poll_interval, max_wait=max_wait)
         return handle

--- a/python/src/acedatacloud/resources/images.py
+++ b/python/src/acedatacloud/resources/images.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
+
+ImageProvider = Literal["nano-banana", "midjourney", "flux", "seedream"]
 
 
 class Images:
@@ -17,6 +19,7 @@ class Images:
         self,
         *,
         prompt: str,
+        provider: ImageProvider | str = "nano-banana",
         model: str | None = None,
         negative_prompt: str | None = None,
         image_url: str | None = None,
@@ -36,13 +39,14 @@ class Images:
         if callback_url is not None:
             body["callback_url"] = callback_url
 
-        result = self._transport.request("POST", "/nano-banana/images", json=body)
+        endpoint = "/midjourney/imagine" if provider == "midjourney" else f"/{provider}/images"
+        result = self._transport.request("POST", endpoint, json=body)
         task_id = result.get("task_id")
 
         if not task_id or (result.get("data") and not wait):
             return result
 
-        handle = TaskHandle(task_id, "/nano-banana/tasks", self._transport)
+        handle = TaskHandle(task_id, f"/{provider}/tasks", self._transport)
         if wait:
             return handle.wait(poll_interval=poll_interval, max_wait=max_wait)
         return handle
@@ -58,6 +62,7 @@ class AsyncImages:
         self,
         *,
         prompt: str,
+        provider: ImageProvider | str = "nano-banana",
         model: str | None = None,
         negative_prompt: str | None = None,
         image_url: str | None = None,
@@ -77,13 +82,14 @@ class AsyncImages:
         if callback_url is not None:
             body["callback_url"] = callback_url
 
-        result = await self._transport.request("POST", "/nano-banana/images", json=body)
+        endpoint = "/midjourney/imagine" if provider == "midjourney" else f"/{provider}/images"
+        result = await self._transport.request("POST", endpoint, json=body)
         task_id = result.get("task_id")
 
         if not task_id or (result.get("data") and not wait):
             return result
 
-        handle = AsyncTaskHandle(task_id, "/nano-banana/tasks", self._transport)
+        handle = AsyncTaskHandle(task_id, f"/{provider}/tasks", self._transport)
         if wait:
             return await handle.wait(poll_interval=poll_interval, max_wait=max_wait)
         return handle

--- a/python/src/acedatacloud/resources/tasks.py
+++ b/python/src/acedatacloud/resources/tasks.py
@@ -8,6 +8,7 @@ from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
 
 _SERVICE_TASK_ENDPOINTS = {
     "suno": "/suno/tasks",
+    "producer": "/producer/tasks",
     "nano-banana": "/nano-banana/tasks",
     "seedream": "/seedream/tasks",
     "seedance": "/seedance/tasks",
@@ -16,6 +17,11 @@ _SERVICE_TASK_ENDPOINTS = {
     "luma": "/luma/tasks",
     "veo": "/veo/tasks",
     "flux": "/flux/tasks",
+    "kling": "/kling/tasks",
+    "hailuo": "/hailuo/tasks",
+    "wan": "/wan/tasks",
+    "pika": "/pika/tasks",
+    "pixverse": "/pixverse/tasks",
 }
 
 

--- a/python/src/acedatacloud/resources/video.py
+++ b/python/src/acedatacloud/resources/video.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
+
+VideoProvider = Literal[
+    "sora", "luma", "veo", "kling", "hailuo", "seedance", "wan", "pika", "pixverse"
+]
 
 
 class Video:
@@ -17,6 +21,7 @@ class Video:
         self,
         *,
         prompt: str,
+        provider: VideoProvider | str = "sora",
         model: str | None = None,
         image_url: str | None = None,
         callback_url: str | None = None,
@@ -33,13 +38,13 @@ class Video:
         if callback_url is not None:
             body["callback_url"] = callback_url
 
-        result = self._transport.request("POST", "/sora/videos", json=body)
+        result = self._transport.request("POST", f"/{provider}/videos", json=body)
         task_id = result.get("task_id")
 
         if not task_id or (result.get("data") and not wait):
             return result
 
-        handle = TaskHandle(task_id, "/sora/tasks", self._transport)
+        handle = TaskHandle(task_id, f"/{provider}/tasks", self._transport)
         if wait:
             return handle.wait(poll_interval=poll_interval, max_wait=max_wait)
         return handle
@@ -55,6 +60,7 @@ class AsyncVideo:
         self,
         *,
         prompt: str,
+        provider: VideoProvider | str = "sora",
         model: str | None = None,
         image_url: str | None = None,
         callback_url: str | None = None,
@@ -71,13 +77,13 @@ class AsyncVideo:
         if callback_url is not None:
             body["callback_url"] = callback_url
 
-        result = await self._transport.request("POST", "/sora/videos", json=body)
+        result = await self._transport.request("POST", f"/{provider}/videos", json=body)
         task_id = result.get("task_id")
 
         if not task_id or (result.get("data") and not wait):
             return result
 
-        handle = AsyncTaskHandle(task_id, "/sora/tasks", self._transport)
+        handle = AsyncTaskHandle(task_id, f"/{provider}/tasks", self._transport)
         if wait:
             return await handle.wait(poll_interval=poll_interval, max_wait=max_wait)
         return handle

--- a/python/src/acedatacloud/resources/video.py
+++ b/python/src/acedatacloud/resources/video.py
@@ -6,9 +6,7 @@ from typing import Any, Literal
 
 from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
 
-VideoProvider = Literal[
-    "sora", "luma", "veo", "kling", "hailuo", "seedance", "wan", "pika", "pixverse"
-]
+VideoProvider = Literal["sora", "luma", "veo", "kling", "hailuo", "seedance", "wan", "pika", "pixverse"]
 
 
 class Video:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -56,10 +56,38 @@ for await (const chunk of stream) {
 ## Image Generation (with Task Polling)
 
 ```typescript
+// Default provider (nano-banana)
 const task = await client.images.generate({ prompt: 'A sunset over mountains' });
 const result = await task.wait();
 console.log(result.image_url);
+
+// Use a specific provider
+const mjTask = await client.images.generate({
+  prompt: 'A sunset over mountains',
+  provider: 'midjourney',
+});
 ```
+
+## Multi-Provider Support
+
+Image, video, and audio resources support a `provider` parameter to switch between services:
+
+```typescript
+// Video — default is 'sora'
+await client.video.generate({ prompt: 'A cat playing piano', provider: 'kling' });
+await client.video.generate({ prompt: 'Ocean waves', provider: 'luma' });
+
+// Audio — default is 'suno'
+await client.audio.generate({ prompt: 'A jazz song', provider: 'producer' });
+```
+
+Available providers:
+
+| Resource | Providers |
+|----------|-----------|
+| `client.images` | `nano-banana` (default), `midjourney`, `flux`, `seedream` |
+| `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse` |
+| `client.audio` | `suno` (default), `producer` |
 
 ## Error Handling
 


### PR DESCRIPTION
## Summary

- Add `provider` parameter to Python SDK `images`, `video`, and `audio` resources with dynamic endpoint routing (matching TypeScript SDK)
- Add missing providers (`producer`, `kling`, `hailuo`, `wan`, `pika`, `pixverse`) to `_SERVICE_TASK_ENDPOINTS`
- Export `ImageProvider`, `VideoProvider`, `AudioProvider` type aliases from package root  
- Update both TypeScript and Python READMEs with multi-provider usage examples and provider tables

## Test plan

- [ ] `ruff check .` passes in `python/`
- [ ] `npx tsc --noEmit` passes in `typescript/`
- [ ] CI (Python Lint, Python Test, TypeScript Lint/Build) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)