### PR TITLE
[codex] repair SDK sync workflow and README examples

### DIFF
--- a/.github/workflows/sync-from-docs.yml
+++ b/.github/workflows/sync-from-docs.yml
@@ -16,12 +16,21 @@ jobs:
     outputs:
       issue_number: ${{ steps.create-issue.outputs.issue_number }}
     steps:
+      - name: Validate sync token
+        env:
+          SYNC_GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$SYNC_GH_TOKEN" ]; then
+            echo "::error::Missing GitHub token. Set ADMIN_GITHUB_TOKEN or BOT_GITHUB_TOKEN."
+            exit 1
+          fi
+
       - name: Checkout Docs
         uses: actions/checkout@v6
         with:
           repository: AceDataCloud/Docs
           path: _docs
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.BOT_GITHUB_TOKEN }}
           fetch-depth: 5
 
       - name: Get Docs changes
@@ -44,7 +53,7 @@ jobs:
 
       - name: Close existing sync issues
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.BOT_GITHUB_TOKEN }}
         run: |
           gh issue list --repo "${{ github.repository }}" --label "auto-sync" --state open --json number --jq '.[].number' | while read -r num; do
             gh issue close "$num" --repo "${{ github.repository }}" --comment "Superseded by new sync trigger." 2>/dev/null || true
@@ -53,63 +62,58 @@ jobs:
       - name: Create issue for Copilot
         id: create-issue
         env:
-          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.BOT_GITHUB_TOKEN }}
           COMMIT_INFO: ${{ steps.docs.outputs.commit_info }}
           RECENT_CHANGES: ${{ steps.docs.outputs.recent_changes }}
           CHANGED_SERVICES: ${{ steps.docs.outputs.changed_services }}
           REPO: ${{ github.repository }}
         run: |
-          ISSUE_URL=$(gh issue create \
-            --repo "$REPO" \
-            --title "sync: update from Docs ($COMMIT_INFO)" \
-            --label "auto-sync" \
-                      --body "The upstream Docs have been updated. Ensure the SDK in this repo is in sync with the latest API specs.
+          body=$(jq -n \
+            --arg changes "$RECENT_CHANGES" \
+            --arg services "$CHANGED_SERVICES" \
+            '"The upstream Docs have been updated. Ensure the SDK in this repo is in sync with the latest API specs.\n\n## Changed Services\n\n`" + $services + "`\n\n## Recent Docs Changes\n\n```\n" + $changes + "\n```\n\n## Instructions\n\nSee `.github/copilot-instructions.md` for sync rules.\n\nThis is a monorepo with `typescript/` and `python/` subdirectories.\n\nCheck the AceDataCloud/Docs repo OpenAPI specs at `openapi/<service>.json` for each changed service.\n\nCompare models, endpoints, parameters, and provider lists against the SDK code. Fix any differences.\n\nIf everything is already in sync, close this issue."')
 
-          ## Changed Services
+          ISSUE_NUM=$(jq -n \
+            --arg title "sync: update from Docs ($COMMIT_INFO)" \
+            --argjson body "$body" \
+            --arg repo "$REPO" \
+            '{
+              title: $title,
+              body: $body,
+              labels: ["auto-sync"],
+              assignees: ["copilot-swe-agent[bot]"],
+              agent_assignment: {
+                target_repo: $repo,
+                base_branch: "main",
+                custom_instructions: "Check out the AceDataCloud/Docs repo and read the openapi/ specs. This is a monorepo — typescript/ and python/ are SDK implementations. Compare the provider lists, endpoints, request/response models against the Docs specs. Update TypeScript types, Python models, and provider enums as needed. Read .github/copilot-instructions.md for detailed sync rules. If everything is already in sync, close this issue with a comment saying so."
+              }
+            }' | gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/"$REPO"/issues \
+            --input - --jq '.number')
 
-          \`$CHANGED_SERVICES\`
-
-          ## Recent Docs Changes
-
-          \`\`\`
-          $RECENT_CHANGES
-          \`\`\`
-
-          ## Instructions
-
-          See \`.github/copilot-instructions.md\` for sync rules.
-
-          This is a monorepo with \`typescript/\` and \`python/\` subdirectories.
-
-          Check the AceDataCloud/Docs repo OpenAPI specs at \`openapi/<service>.json\` for each changed service.
-
-          Compare models, endpoints, parameters, and provider lists against the SDK code. Fix any differences.
-
-          If everything is already in sync, close this issue." \
-            2>&1 || echo "")
-
-          if [ -z "$ISSUE_URL" ]; then
-            echo "Failed to create issue"
-            exit 1
-          fi
-
-          ISSUE_NUMBER=$(echo "$ISSUE_URL" | grep -oE "[0-9]+$")
-          echo "Created issue #$ISSUE_NUMBER"
-          echo "issue_number=$ISSUE_NUMBER" >> "$GITHUB_OUTPUT"
-
-          # Assign Copilot bot via API (gh issue create can't resolve bot accounts)
-          echo '{"assignees":["copilot-swe-agent[bot]"]}' | gh api --method POST \
-            "repos/${{ github.repository }}/issues/$ISSUE_NUMBER/assignees" \
-            --input - > /dev/null 2>&1 || echo "Warning: could not assign bot, continuing"
+          echo "Created issue #$ISSUE_NUM"
+          echo "issue_number=$ISSUE_NUM" >> "$GITHUB_OUTPUT"
 
   wait-and-merge:
     needs: create-task
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
+      - name: Validate sync token
+        env:
+          SYNC_GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.BOT_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$SYNC_GH_TOKEN" ]; then
+            echo "::error::Missing GitHub token. Set ADMIN_GITHUB_TOKEN or BOT_GITHUB_TOKEN."
+            exit 1
+          fi
+
       - name: Wait for Copilot PR and merge
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN || secrets.BOT_GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ needs.create-task.outputs.issue_number }}
         run: |
           echo "Waiting for Copilot to process issue #$ISSUE_NUMBER..."
@@ -133,10 +137,18 @@ jobs:
               HEAD_BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
               echo "Found PR #$PR_NUMBER: $PR_TITLE (branch=$HEAD_BRANCH)"
 
-              AGENT_STATUS=$(gh api "/repos/${{ github.repository }}/actions/runs?branch=$HEAD_BRANCH&event=dynamic" \
-                --jq '[.workflow_runs[] | select(.name == "Running Copilot coding agent")] | .[0].conclusion // "pending"' 2>/dev/null || echo "pending")
+              AGENT_RUN=$(gh api "/repos/${{ github.repository }}/actions/runs?branch=$HEAD_BRANCH&event=dynamic" \
+                --jq '[.workflow_runs[] | {name: .name, status: .status, conclusion: (.conclusion // ""), created_at: .created_at}] | sort_by(.created_at) | reverse | .[0] // empty' 2>/dev/null || echo "")
 
-              echo "Copilot agent status: $AGENT_STATUS"
+              if [ -n "$AGENT_RUN" ]; then
+                AGENT_NAME=$(echo "$AGENT_RUN" | jq -r '.name')
+                AGENT_PHASE=$(echo "$AGENT_RUN" | jq -r '.status')
+                AGENT_STATUS=$(echo "$AGENT_RUN" | jq -r 'if .status == "completed" then (.conclusion // "failure") else "pending" end')
+                echo "Latest dynamic run: $AGENT_NAME (phase=$AGENT_PHASE, conclusion=$AGENT_STATUS)"
+              else
+                AGENT_STATUS="pending"
+                echo "No dynamic workflow run found yet for branch $HEAD_BRANCH"
+              fi
 
               if [ "$AGENT_STATUS" = "success" ]; then
                 echo "Copilot agent completed. Merging PR #$PR_NUMBER..."

--- a/python/README.md
+++ b/python/README.md
@@ -39,7 +39,7 @@ from acedatacloud import AsyncAceDataCloud
 
 async def main():
     client = AsyncAceDataCloud(api_token="your-token")
-    result = await client.search.google(q="Python SDK")
+    result = await client.search.google(query="Python SDK")
     print(result)
     await client.close()
 
@@ -100,7 +100,7 @@ from acedatacloud import AceDataCloud, AuthenticationError, RateLimitError
 
 client = AceDataCloud(api_token="your-token")
 try:
-    client.search.google(q="test")
+    client.search.google(query="test")
 except AuthenticationError:
     print("Invalid or expired token")
 except RateLimitError:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -96,7 +96,7 @@ import { AceDataCloud, AuthenticationError, RateLimitError } from '@acedatacloud
 
 const client = new AceDataCloud({ apiToken: 'your-token' });
 try {
-  await client.search.google({ q: 'test' });
+  await client.search.google({ query: 'test' });
 } catch (err) {
   if (err instanceof AuthenticationError) {
     console.error('Invalid or expired token');


### PR DESCRIPTION
## What changed
- repaired `.github/workflows/sync-from-docs.yml`
- replaced the broken multiline issue creation block with a YAML-safe JSON payload flow
- added token validation and fallback support for `ADMIN_GITHUB_TOKEN || BOT_GITHUB_TOKEN`
- updated Copilot run detection to follow the latest dynamic run on the PR branch instead of one fixed run name
- fixed README examples to use `query` instead of `q` for `search.google` in both Python and TypeScript

## Why
The SDK sync workflow had two separate problems: the issue-creation script on `main` was structurally fragile, and the wait step depended on a fixed Copilot run name. Separately, the README examples were out of sync with the actual SDK API and produced a DX bug on copy-paste.

## Impact
- Docs-driven sync should be able to create and merge PRs more reliably
- token-name drift should stop causing silent workflow failures
- README search examples now match the implemented SDK interface

## Validation
- parsed `.github/workflows/sync-from-docs.yml` locally with Ruby `YAML.load_file`
- verified the README examples now use `query` in both SDKs
- reviewed the rebased diff on a clean branch from `origin/main`
