### PR TITLE
[codex] docs: add fish audio provider to SDK READMEs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -53,7 +53,7 @@ asyncio.run(main())
 | `client.openai` | OpenAI-compatible chat completions and responses |
 | `client.chat` | Native chat messages |
 | `client.images` | Image generation (Midjourney, Flux, etc.) |
-| `client.audio` | Music generation (Suno) |
+| `client.audio` | Music generation (Suno, Producer, Fish) |
 | `client.video` | Video generation (Luma, Sora, Veo, etc.) |
 | `client.search` | Web search (Google SERP) |
 | `client.tasks` | Cross-service async task polling |
@@ -83,6 +83,7 @@ client.video.generate(prompt="Ocean waves", provider="luma")
 
 # Audio — default is 'suno'
 client.audio.generate(prompt="A jazz song", provider="producer")
+client.audio.generate(prompt="A podcast intro", provider="fish")
 ```
 
 Available providers:
@@ -91,7 +92,7 @@ Available providers:
 |----------|-----------|
 | `client.images` | `nano-banana` (default), `midjourney`, `flux`, `seedream` |
 | `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse` |
-| `client.audio` | `suno` (default), `producer` |
+| `client.audio` | `suno` (default), `producer`, `fish` |
 
 ## Error Handling
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -46,7 +46,7 @@ for await (const chunk of stream) {
 | `client.openai` | OpenAI-compatible chat completions and responses |
 | `client.chat` | Native chat messages |
 | `client.images` | Image generation (Midjourney, Flux, etc.) |
-| `client.audio` | Music generation (Suno) |
+| `client.audio` | Music generation (Suno, Producer, Fish) |
 | `client.video` | Video generation (Luma, Sora, Veo, etc.) |
 | `client.search` | Web search (Google SERP) |
 | `client.tasks` | Cross-service async task polling |
@@ -79,6 +79,7 @@ await client.video.generate({ prompt: 'Ocean waves', provider: 'luma' });
 
 // Audio — default is 'suno'
 await client.audio.generate({ prompt: 'A jazz song', provider: 'producer' });
+await client.audio.generate({ prompt: 'A podcast intro', provider: 'fish' });
 ```
 
 Available providers:
@@ -87,7 +88,7 @@ Available providers:
 |----------|-----------|
 | `client.images` | `nano-banana` (default), `midjourney`, `flux`, `seedream` |
 | `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse` |
-| `client.audio` | `suno` (default), `producer` |
+| `client.audio` | `suno` (default), `producer`, `fish` |
 
 ## Error Handling
 


### PR DESCRIPTION
## What changed
- updated the Python and TypeScript SDK READMEs to list `fish` as a supported audio provider
- refreshed the audio examples so the provider appears in the usage snippets as well

## Why
The SDK implementation already supports `fish` in both languages, but the public READMEs still only documented `suno` and `producer`.

## Impact
Users reading the SDK docs now see the current audio provider surface without needing to inspect the source.

## Validation
- docs-only change
- cross-checked against `python/src/acedatacloud/resources/audio.py`
- cross-checked against `typescript/src/resources/audio.ts`
- cross-checked against task routing in `python/src/acedatacloud/resources/tasks.py` and `typescript/src/resources/tasks.ts`
