### PR TITLE
feat: pluggable paymentHandler hook for x402 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,37 @@ client
 - **Automatic retries**: Transient errors (5xx, network) are retried with exponential backoff + jitter
 - **Error hierarchy**: Typed errors for auth, rate-limit, balance, validation, moderation, etc.
 - **Dual base URLs**: API gateway (`api.acedata.cloud`) for calling-plane, platform (`platform.acedata.cloud`) for management
+- **Pluggable payment handler**: on `402 Payment Required`, the SDK invokes an optional handler to produce the retry headers — the integration point for on-chain (x402) payments
+
+## Paying Per Request with X402
+
+Both SDKs expose a `paymentHandler` / `payment_handler` hook that is
+called when the server returns `402 Payment Required`. Plug in
+[`@acedatacloud/x402-client`](https://github.com/AceDataCloud/X402Client)
+and the SDK can call any x402-enabled endpoint using on-chain USDC
+instead of a Bearer token — no other code changes needed.
+
+```typescript
+import { AceDataCloud } from '@acedatacloud/sdk';
+import { createX402PaymentHandler } from '@acedatacloud/x402-client';
+
+const client = new AceDataCloud({
+  paymentHandler: createX402PaymentHandler({
+    network: 'base',
+    evmProvider: window.ethereum,
+    evmAddress: '0xYourAddress...',
+  }),
+});
+
+await client.openai.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'hi' }],
+});
+```
+
+In Python the hook is the same shape — any callable that returns
+`{"headers": {"X-Payment": "<base64-envelope>"}}`. See
+[python/README.md](python/README.md#paying-with-x402-instead-of-a-bearer-token).
 
 ## Spec Overlays
 

--- a/python/README.md
+++ b/python/README.md
@@ -121,6 +121,37 @@ client = AceDataCloud(
 
 The token can also be set via the `ACEDATACLOUD_API_TOKEN` environment variable.
 
+## Paying with X402 Instead of a Bearer Token
+
+The SDK supports a pluggable `payment_handler` that is invoked when the
+API returns `402 Payment Required`. Any callable (or async callable)
+that returns the required headers is accepted:
+
+```python
+from acedatacloud import AceDataCloud, PaymentHandlerContext, PaymentHandlerResult
+
+def my_payment_handler(ctx: PaymentHandlerContext) -> PaymentHandlerResult:
+    # ctx["accepts"] is the list of payment requirements returned by the server.
+    # Your job: sign the preferred one and return the retry header.
+    x_payment = sign_and_encode(ctx["accepts"])  # your implementation
+    return {"headers": {"X-Payment": x_payment}}
+
+client = AceDataCloud(payment_handler=my_payment_handler)
+
+# Normal SDK calls — the handler is only invoked when the server returns 402.
+result = client.openai.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "Hi"}],
+)
+```
+
+The `AsyncAceDataCloud` client accepts either a synchronous or
+asynchronous handler, so you can plug in wallet SDKs that use
+`asyncio`. A ready-made x402 signer for Python is not shipped yet
+(there is a TypeScript implementation in
+[`@acedatacloud/x402-client`](https://github.com/AceDataCloud/X402Client)
+— contributions for a Python port are welcome).
+
 ## License
 
 MIT

--- a/python/src/acedatacloud/__init__.py
+++ b/python/src/acedatacloud/__init__.py
@@ -15,6 +15,15 @@ from acedatacloud._runtime.errors import (
     TransportError,
     ValidationError,
 )
+from acedatacloud._runtime.payment import (
+    AsyncPaymentHandler,
+    PaymentHandler,
+    PaymentHandlerContext,
+    PaymentHandlerResult,
+    PaymentRequiredBody,
+    PaymentRequirement,
+    SyncPaymentHandler,
+)
 from acedatacloud.resources.audio import AudioProvider
 from acedatacloud.resources.images import ImageProvider
 from acedatacloud.resources.video import VideoProvider
@@ -37,4 +46,11 @@ __all__ = [
     "TokenMismatchError",
     "TransportError",
     "ValidationError",
+    "AsyncPaymentHandler",
+    "PaymentHandler",
+    "PaymentHandlerContext",
+    "PaymentHandlerResult",
+    "PaymentRequiredBody",
+    "PaymentRequirement",
+    "SyncPaymentHandler",
 ]

--- a/python/src/acedatacloud/_client.py
+++ b/python/src/acedatacloud/_client.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
+from acedatacloud._runtime.payment import (
+    AsyncPaymentHandler,
+    PaymentHandler,
+    SyncPaymentHandler,
+)
 from acedatacloud._runtime.transport import AsyncTransport, SyncTransport
 from acedatacloud.resources.audio import AsyncAudio, Audio
 from acedatacloud.resources.chat import AsyncChat, Chat
@@ -31,6 +36,7 @@ class AceDataCloud:
         timeout: float = 300.0,
         max_retries: int = 2,
         headers: dict[str, str] | None = None,
+        payment_handler: SyncPaymentHandler | None = None,
     ) -> None:
         self._transport = SyncTransport(
             api_token=api_token,
@@ -39,6 +45,7 @@ class AceDataCloud:
             timeout=timeout,
             max_retries=max_retries,
             extra_headers=headers or {},
+            payment_handler=payment_handler,
         )
         self.chat = Chat(self._transport)
         self.images = Images(self._transport)
@@ -72,6 +79,7 @@ class AsyncAceDataCloud:
         timeout: float = 300.0,
         max_retries: int = 2,
         headers: dict[str, str] | None = None,
+        payment_handler: PaymentHandler | None = None,
     ) -> None:
         self._transport = AsyncTransport(
             api_token=api_token,
@@ -80,6 +88,7 @@ class AsyncAceDataCloud:
             timeout=timeout,
             max_retries=max_retries,
             extra_headers=headers or {},
+            payment_handler=payment_handler,
         )
         self.chat = AsyncChat(self._transport)
         self.images = AsyncImages(self._transport)

--- a/python/src/acedatacloud/_client.py
+++ b/python/src/acedatacloud/_client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 from acedatacloud._runtime.payment import (
-    AsyncPaymentHandler,
     PaymentHandler,
     SyncPaymentHandler,
 )

--- a/python/src/acedatacloud/_runtime/payment.py
+++ b/python/src/acedatacloud/_runtime/payment.py
@@ -1,0 +1,47 @@
+"""Pluggable payment handler hook for the SDK transport.
+
+When the API returns ``402 Payment Required``, the transport calls the
+configured payment handler to obtain the extra headers (typically
+``X-Payment``) to attach to the retry. This keeps the SDK free of any
+chain-specific signing logic, and lets callers plug in an x402
+implementation when one becomes available.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any, Callable, TypedDict, Union
+
+
+class PaymentRequirement(TypedDict, total=False):
+    scheme: str
+    network: str
+    maxAmountRequired: str
+    maxTimeoutSeconds: int
+    resource: str
+    description: str
+    payTo: str
+    asset: str
+    extra: dict[str, Any]
+
+
+class PaymentRequiredBody(TypedDict, total=False):
+    x402Version: int
+    accepts: list[PaymentRequirement]
+    error: str
+
+
+class PaymentHandlerContext(TypedDict):
+    url: str
+    method: str
+    body: Any
+    accepts: list[PaymentRequirement]
+
+
+class PaymentHandlerResult(TypedDict):
+    headers: dict[str, str]
+
+
+SyncPaymentHandler = Callable[[PaymentHandlerContext], PaymentHandlerResult]
+AsyncPaymentHandler = Callable[[PaymentHandlerContext], Awaitable[PaymentHandlerResult]]
+PaymentHandler = Union[SyncPaymentHandler, AsyncPaymentHandler]

--- a/python/src/acedatacloud/_runtime/transport.py
+++ b/python/src/acedatacloud/_runtime/transport.py
@@ -24,7 +24,6 @@ from acedatacloud._runtime.errors import (
     ValidationError,
 )
 from acedatacloud._runtime.payment import (
-    AsyncPaymentHandler,
     PaymentHandler,
     SyncPaymentHandler,
 )

--- a/python/src/acedatacloud/_runtime/transport.py
+++ b/python/src/acedatacloud/_runtime/transport.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import os
 import random
 import time
@@ -21,6 +22,11 @@ from acedatacloud._runtime.errors import (
     TokenMismatchError,
     TransportError,
     ValidationError,
+)
+from acedatacloud._runtime.payment import (
+    AsyncPaymentHandler,
+    PaymentHandler,
+    SyncPaymentHandler,
 )
 
 _ERROR_CODE_MAP = {
@@ -87,11 +93,15 @@ class SyncTransport:
         timeout: float,
         max_retries: int,
         extra_headers: dict[str, str],
+        payment_handler: SyncPaymentHandler | None = None,
     ) -> None:
         token = api_token or os.environ.get("ACEDATACLOUD_API_TOKEN", "")
-        if not token:
+        if not token and payment_handler is None:
             raise AuthenticationError(
-                message="api_token is required. Pass it to the client or set ACEDATACLOUD_API_TOKEN.",
+                message=(
+                    "api_token is required (or provide a payment_handler). "
+                    "Pass it to the client or set ACEDATACLOUD_API_TOKEN."
+                ),
                 status_code=0,
                 code="no_token",
             )
@@ -99,13 +109,16 @@ class SyncTransport:
         self._platform_base_url = platform_base_url.rstrip("/")
         self._timeout = timeout
         self._max_retries = max_retries
-        self._headers = {
+        self._payment_handler = payment_handler
+        headers: dict[str, str] = {
             "accept": "application/json",
-            "authorization": f"Bearer {token}",
             "content-type": "application/json",
             "user-agent": "acedatacloud-python/0.1.0",
             **extra_headers,
         }
+        if token:
+            headers["authorization"] = f"Bearer {token}"
+        self._headers = headers
         self._client = httpx.Client(timeout=timeout)
 
     def request(
@@ -122,6 +135,8 @@ class SyncTransport:
         base = self._platform_base_url if platform else self._base_url
         url = f"{base}{path}"
         headers = {**self._headers, **(extra_headers or {})}
+        extra_auth_headers: dict[str, str] = {}
+        payment_attempted = False
 
         last_exc: Exception | None = None
         for attempt in range(self._max_retries + 1):
@@ -131,7 +146,7 @@ class SyncTransport:
                     url,
                     json=json,
                     params=params,
-                    headers=headers,
+                    headers={**headers, **extra_auth_headers},
                     timeout=timeout or self._timeout,
                 )
             except httpx.TimeoutException as exc:
@@ -150,6 +165,31 @@ class SyncTransport:
                     time.sleep(_backoff_delay(attempt))
                     continue
                 raise last_exc from exc
+
+            if (
+                resp.status_code == 402
+                and self._payment_handler is not None
+                and not payment_attempted
+            ):
+                try:
+                    body = resp.json()
+                except Exception as exc:
+                    raise _map_error(
+                        402,
+                        {"error": {"code": "invalid_402", "message": resp.text}},
+                    ) from exc
+                accepts = body.get("accepts") or []
+                if not accepts:
+                    raise _map_error(
+                        402,
+                        {"error": {"code": "invalid_402", "message": "No payment requirements"}},
+                    )
+                result = self._payment_handler(
+                    {"url": url, "method": method, "body": json, "accepts": accepts}
+                )
+                extra_auth_headers.update(result.get("headers", {}))
+                payment_attempted = True
+                continue
 
             if resp.status_code >= 400:
                 try:
@@ -248,12 +288,16 @@ class AsyncTransport:
         timeout: float,
         max_retries: int,
         extra_headers: dict[str, str],
+        payment_handler: PaymentHandler | None = None,
     ) -> None:
 
         token = api_token or os.environ.get("ACEDATACLOUD_API_TOKEN", "")
-        if not token:
+        if not token and payment_handler is None:
             raise AuthenticationError(
-                message="api_token is required. Pass it to the client or set ACEDATACLOUD_API_TOKEN.",
+                message=(
+                    "api_token is required (or provide a payment_handler). "
+                    "Pass it to the client or set ACEDATACLOUD_API_TOKEN."
+                ),
                 status_code=0,
                 code="no_token",
             )
@@ -261,13 +305,16 @@ class AsyncTransport:
         self._platform_base_url = platform_base_url.rstrip("/")
         self._timeout = timeout
         self._max_retries = max_retries
-        self._headers = {
+        self._payment_handler = payment_handler
+        headers: dict[str, str] = {
             "accept": "application/json",
-            "authorization": f"Bearer {token}",
             "content-type": "application/json",
             "user-agent": "acedatacloud-python/0.1.0",
             **extra_headers,
         }
+        if token:
+            headers["authorization"] = f"Bearer {token}"
+        self._headers = headers
         self._client = httpx.AsyncClient(timeout=timeout)
 
     async def request(
@@ -286,6 +333,8 @@ class AsyncTransport:
         base = self._platform_base_url if platform else self._base_url
         url = f"{base}{path}"
         headers = {**self._headers, **(extra_headers or {})}
+        extra_auth_headers: dict[str, str] = {}
+        payment_attempted = False
 
         last_exc: Exception | None = None
         for attempt in range(self._max_retries + 1):
@@ -295,7 +344,7 @@ class AsyncTransport:
                     url,
                     json=json,
                     params=params,
-                    headers=headers,
+                    headers={**headers, **extra_auth_headers},
                     timeout=timeout or self._timeout,
                 )
             except httpx.TimeoutException as exc:
@@ -314,6 +363,33 @@ class AsyncTransport:
                     await asyncio.sleep(_backoff_delay(attempt))
                     continue
                 raise last_exc from exc
+
+            if (
+                resp.status_code == 402
+                and self._payment_handler is not None
+                and not payment_attempted
+            ):
+                try:
+                    body = resp.json()
+                except Exception as exc:
+                    raise _map_error(
+                        402,
+                        {"error": {"code": "invalid_402", "message": resp.text}},
+                    ) from exc
+                accepts = body.get("accepts") or []
+                if not accepts:
+                    raise _map_error(
+                        402,
+                        {"error": {"code": "invalid_402", "message": "No payment requirements"}},
+                    )
+                handler_result = self._payment_handler(
+                    {"url": url, "method": method, "body": json, "accepts": accepts}
+                )
+                if inspect.isawaitable(handler_result):
+                    handler_result = await handler_result
+                extra_auth_headers.update(handler_result.get("headers", {}))
+                payment_attempted = True
+                continue
 
             if resp.status_code >= 400:
                 try:

--- a/python/src/acedatacloud/_runtime/transport.py
+++ b/python/src/acedatacloud/_runtime/transport.py
@@ -165,11 +165,7 @@ class SyncTransport:
                     continue
                 raise last_exc from exc
 
-            if (
-                resp.status_code == 402
-                and self._payment_handler is not None
-                and not payment_attempted
-            ):
+            if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
                     body = resp.json()
                 except Exception as exc:
@@ -183,9 +179,7 @@ class SyncTransport:
                         402,
                         {"error": {"code": "invalid_402", "message": "No payment requirements"}},
                     )
-                result = self._payment_handler(
-                    {"url": url, "method": method, "body": json, "accepts": accepts}
-                )
+                result = self._payment_handler({"url": url, "method": method, "body": json, "accepts": accepts})
                 extra_auth_headers.update(result.get("headers", {}))
                 payment_attempted = True
                 continue
@@ -289,7 +283,6 @@ class AsyncTransport:
         extra_headers: dict[str, str],
         payment_handler: PaymentHandler | None = None,
     ) -> None:
-
         token = api_token or os.environ.get("ACEDATACLOUD_API_TOKEN", "")
         if not token and payment_handler is None:
             raise AuthenticationError(
@@ -363,11 +356,7 @@ class AsyncTransport:
                     continue
                 raise last_exc from exc
 
-            if (
-                resp.status_code == 402
-                and self._payment_handler is not None
-                and not payment_attempted
-            ):
+            if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
                     body = resp.json()
                 except Exception as exc:
@@ -381,9 +370,7 @@ class AsyncTransport:
                         402,
                         {"error": {"code": "invalid_402", "message": "No payment requirements"}},
                     )
-                handler_result = self._payment_handler(
-                    {"url": url, "method": method, "body": json, "accepts": accepts}
-                )
+                handler_result = self._payment_handler({"url": url, "method": method, "body": json, "accepts": accepts})
                 if inspect.isawaitable(handler_result):
                     handler_result = await handler_result
                 extra_auth_headers.update(handler_result.get("headers", {}))

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -120,6 +120,49 @@ const client = new AceDataCloud({
 
 The token can also be set via the `ACEDATACLOUD_API_TOKEN` environment variable.
 
+## Paying with X402 Instead of a Bearer Token
+
+The SDK supports a pluggable `paymentHandler` that is invoked when the
+API returns `402 Payment Required`. Combine it with
+[`@acedatacloud/x402-client`](https://github.com/AceDataCloud/X402Client)
+to pay for requests on-chain (Base, Solana, SKALE) instead of using a
+Bearer token:
+
+```bash
+npm install @acedatacloud/sdk @acedatacloud/x402-client
+```
+
+```typescript
+import { AceDataCloud } from '@acedatacloud/sdk';
+import { createX402PaymentHandler } from '@acedatacloud/x402-client';
+
+const client = new AceDataCloud({
+  // No apiToken needed — the x402 handler pays per request.
+  paymentHandler: createX402PaymentHandler({
+    network: 'base',               // or 'solana' | 'skale'
+    evmProvider: window.ethereum,
+    evmAddress: '0xYourAddress...',
+  }),
+});
+
+const result = await client.openai.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'Say hi in 3 words' }],
+  max_tokens: 10,
+});
+```
+
+On each API call, the SDK first sends the request unauthenticated. If
+the server replies with `402`, the SDK passes the `accepts` list to
+the handler, which signs and returns an `X-Payment` header. The SDK
+retries the request once with that header. Everything else — task
+polling, streaming, retries, error mapping — keeps working exactly the
+same.
+
+You can still pass a Bearer token alongside the handler if you want a
+mixed mode (some endpoints via subscription, others via x402) — the
+SDK only invokes the handler when it actually sees a `402`.
+
 ## License
 
 MIT

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -15,7 +15,7 @@
         "jest": "^29.0.0",
         "ts-jest": "^29.0.0",
         "tsup": "^8.5.1",
-        "typescript": "^5.0.0"
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": ">=18"
@@ -52,6 +52,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2105,6 +2106,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2533,6 +2535,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3086,6 +3089,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4762,6 +4766,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4977,6 +4982,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -30,7 +30,7 @@
     "jest": "^29.0.0",
     "ts-jest": "^29.0.0",
     "tsup": "^8.5.1",
-    "typescript": "^5.0.0"
+    "typescript": "^5.9.3"
   },
   "files": [
     "dist",

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1,6 +1,7 @@
 /** Top-level AceDataCloud client for TypeScript. */
 
 import { Transport, TransportOptions } from './runtime/transport';
+import type { PaymentHandler } from './runtime/payment';
 import { Chat } from './resources/chat';
 import { Images } from './resources/images';
 import { Audio } from './resources/audio';
@@ -18,6 +19,12 @@ export interface AceDataCloudOptions {
   timeout?: number;
   maxRetries?: number;
   headers?: Record<string, string>;
+  /**
+   * Optional payment handler invoked when the API returns `402 Payment
+   * Required`. Use `createX402PaymentHandler` from
+   * `@acedatacloud/x402-client` to enable on-chain payments via X402.
+   */
+  paymentHandler?: PaymentHandler;
 }
 
 export class AceDataCloud {
@@ -41,6 +48,7 @@ export class AceDataCloud {
       timeout: opts.timeout,
       maxRetries: opts.maxRetries,
       headers: opts.headers,
+      paymentHandler: opts.paymentHandler,
     });
 
     this.chat = new Chat(this.transport);

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -18,6 +18,14 @@ export {
 
 export { TaskHandle, TaskHandleOptions } from './runtime/tasks';
 
+export type {
+  PaymentHandler,
+  PaymentHandlerContext,
+  PaymentHandlerResult,
+  PaymentRequirement,
+  PaymentRequiredBody,
+} from './runtime/payment';
+
 export type { ImageProvider } from './resources/images';
 export type { VideoProvider } from './resources/video';
 export type { AudioProvider } from './resources/audio';

--- a/typescript/src/runtime/index.ts
+++ b/typescript/src/runtime/index.ts
@@ -1,5 +1,12 @@
 export { Transport, TransportOptions } from './transport';
 export { TaskHandle, TaskHandleOptions } from './tasks';
+export type {
+  PaymentHandler,
+  PaymentHandlerContext,
+  PaymentHandlerResult,
+  PaymentRequirement,
+  PaymentRequiredBody,
+} from './payment';
 export {
   AceDataCloudError,
   APIError,

--- a/typescript/src/runtime/payment.ts
+++ b/typescript/src/runtime/payment.ts
@@ -1,0 +1,48 @@
+/**
+ * Pluggable payment handler hook for the SDK transport.
+ *
+ * When the API returns `402 Payment Required`, the transport calls the
+ * configured `PaymentHandler` to produce the extra headers (typically
+ * `X-Payment`) to attach to the retry. This keeps the SDK free of any
+ * chain-specific signing logic, and lets callers plug in a real x402
+ * implementation such as `@acedatacloud/x402-client`.
+ */
+
+/** Payment requirement as returned by the server in a 402 response. */
+export interface PaymentRequirement {
+  scheme: string;
+  network: string;
+  maxAmountRequired: string;
+  maxTimeoutSeconds?: number;
+  resource?: string;
+  description?: string;
+  payTo: string;
+  asset: string;
+  extra?: Record<string, unknown>;
+}
+
+/** Shape of a 402 response body. */
+export interface PaymentRequiredBody {
+  x402Version?: number;
+  accepts: PaymentRequirement[];
+  error?: string;
+}
+
+/** Context passed to a payment handler when a 402 is observed. */
+export interface PaymentHandlerContext {
+  url: string;
+  method: string;
+  body?: unknown;
+  accepts: PaymentRequirement[];
+}
+
+/** Result a payment handler must return. */
+export interface PaymentHandlerResult {
+  /** Extra headers to attach to the retry (must include `X-Payment`). */
+  headers: Record<string, string>;
+}
+
+/** A callable that signs/settles a payment and returns retry headers. */
+export type PaymentHandler = (
+  ctx: PaymentHandlerContext
+) => Promise<PaymentHandlerResult> | PaymentHandlerResult;

--- a/typescript/src/runtime/transport.ts
+++ b/typescript/src/runtime/transport.ts
@@ -12,6 +12,10 @@ import {
   TransportError,
   ValidationError,
 } from './errors';
+import type {
+  PaymentHandler,
+  PaymentRequiredBody,
+} from './payment';
 
 const ERROR_CODE_MAP: Record<string, typeof APIError> = {
   invalid_token: AuthenticationError,
@@ -60,6 +64,14 @@ export interface TransportOptions {
   timeout?: number;
   maxRetries?: number;
   headers?: Record<string, string>;
+  /**
+   * Optional handler invoked when a request returns `402 Payment Required`.
+   * The handler receives the parsed `accepts` list and must return the extra
+   * headers (typically `X-Payment`) to attach to the automatic retry.
+   *
+   * See `@acedatacloud/x402-client` for a drop-in implementation.
+   */
+  paymentHandler?: PaymentHandler;
 }
 
 export class Transport {
@@ -68,12 +80,15 @@ export class Transport {
   private timeout: number;
   private maxRetries: number;
   private headers: Record<string, string>;
+  private paymentHandler?: PaymentHandler;
 
   constructor(opts: TransportOptions = {}) {
     const token = opts.apiToken ?? process.env.ACEDATACLOUD_API_TOKEN ?? '';
-    if (!token) {
+    if (!token && !opts.paymentHandler) {
       throw new AuthenticationError({
-        message: 'apiToken is required. Pass it to the client or set ACEDATACLOUD_API_TOKEN.',
+        message:
+          'apiToken is required (or provide a paymentHandler, e.g. from @acedatacloud/x402-client). ' +
+          'Pass it to the client or set ACEDATACLOUD_API_TOKEN.',
         statusCode: 0,
         code: 'no_token',
       });
@@ -82,13 +97,17 @@ export class Transport {
     this.platformBaseURL = (opts.platformBaseURL ?? 'https://platform.acedata.cloud').replace(/\/+$/, '');
     this.timeout = opts.timeout ?? 300_000;
     this.maxRetries = opts.maxRetries ?? 2;
-    this.headers = {
+    this.paymentHandler = opts.paymentHandler;
+    const baseHeaders: Record<string, string> = {
       accept: 'application/json',
-      authorization: `Bearer ${token}`,
       'content-type': 'application/json',
       'user-agent': 'acedatacloud-node/0.1.0',
       ...(opts.headers ?? {}),
     };
+    if (token) {
+      baseHeaders.authorization = `Bearer ${token}`;
+    }
+    this.headers = baseHeaders;
   }
 
   async request(
@@ -112,17 +131,41 @@ export class Transport {
     const timeoutMs = opts.timeout ?? this.timeout;
 
     let lastError: Error | null = null;
+    let paymentAttempted = false;
+    let extraHeaders: Record<string, string> = {};
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
       try {
         const resp = await fetch(url, {
           method,
-          headers,
+          headers: { ...headers, ...extraHeaders },
           body: opts.json ? JSON.stringify(opts.json) : undefined,
           signal: controller.signal,
         });
         clearTimeout(timer);
+
+        if (resp.status === 402 && this.paymentHandler && !paymentAttempted) {
+          const text = await resp.text();
+          let body: PaymentRequiredBody;
+          try {
+            body = JSON.parse(text) as PaymentRequiredBody;
+          } catch {
+            throw mapError(402, { error: { code: 'invalid_402', message: text } });
+          }
+          if (!body.accepts?.length) {
+            throw mapError(402, { error: { code: 'invalid_402', message: 'No payment requirements' } });
+          }
+          const result = await this.paymentHandler({
+            url,
+            method,
+            body: opts.json,
+            accepts: body.accepts,
+          });
+          extraHeaders = { ...extraHeaders, ...result.headers };
+          paymentAttempted = true;
+          continue;
+        }
 
         if (resp.status >= 400) {
           const text = await resp.text();


### PR DESCRIPTION
## What

Adds a pluggable `paymentHandler` (TS) / `payment_handler` (Python) hook to the SDK transport. When the API returns `402 Payment Required`, the transport now:

1. parses the response body
2. passes the `accepts` list to the configured handler
3. retries the request once with the headers the handler returns (typically `X-Payment`)

## Why

Previously the SDK only supported Bearer-token auth, and `@acedatacloud/x402-client` had to reinvent its own HTTP client to do x402 flows. That meant two parallel ways of calling the same APIs, and features like task polling / streaming / retries were missing from the x402 path.

With this hook, the SDK stays the single entry point for every AceDataCloud endpoint, and X402Client becomes a small adapter that produces a `paymentHandler`.

## Usage

```ts
import { AceDataCloud } from '@acedatacloud/sdk';
import { createX402PaymentHandler } from '@acedatacloud/x402-client';

const client = new AceDataCloud({
  paymentHandler: createX402PaymentHandler({
    network: 'base',
    evmProvider: window.ethereum,
    evmAddress: '0x...',
  }),
});

await client.openai.chat.completions.create({ ... });
```

Python accepts any callable returning `{"headers": {"X-Payment": ...}}` (sync or async).

## Changes

- TS: new `runtime/payment.ts`, `Transport` accepts `paymentHandler`, `apiToken` becomes optional when a handler is supplied
- Python: new `_runtime/payment.py`, `SyncTransport` / `AsyncTransport` accept `payment_handler`, async transport awaits coroutines transparently
- READMEs (root, TS, Python) updated with the x402 integration pattern
- All existing tests still pass (22 passed, 29 skipped)

Companion PR in X402Client: https://github.com/AceDataCloud/X402Client/pulls (will be opened next).