### PR TITLE
feat: add Go SDK

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,44 @@
+name: Go CI
+
+on:
+  pull_request:
+    paths:
+      - "go/**"
+      - ".github/workflows/go.yml"
+  push:
+    branches: [main]
+    paths:
+      - "go/**"
+      - ".github/workflows/go.yml"
+
+jobs:
+  test:
+    name: Go ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.21", "1.22", "1.23"]
+    defaults:
+      run:
+        working-directory: go
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: go/go.sum
+
+      - name: go mod download
+        run: go mod download
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test -race -count=1 ./...

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Official SDK clients for the [AceDataCloud API](https://platform.acedata.cloud).
 |----------|-----------|---------|
 | Python | [python](python/) | `acedatacloud` |
 | TypeScript | [typescript](typescript/) | `@acedatacloud/sdk` |
+| Go | [go](go/) | `github.com/AceDataCloud/SDK/go` |
 
 ## Architecture
 

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,123 @@
+# AceDataCloud Go SDK
+
+Official Go client for the [AceDataCloud API](https://platform.acedata.cloud).
+
+Mirrors the design of the [Python](../python) and [TypeScript](../typescript) SDKs:
+
+- Top-level `Client` with functional options.
+- Domain resources: `OpenAI` (chat / responses), `Chat` (native messages), `Images`, `Tasks`.
+- Automatic retries with exponential backoff on 408/409/429/5xx.
+- `TaskHandle` for polling long-running image / audio / video tasks.
+- Pluggable `PaymentHandler` hook for on-chain x402 payments — see the
+  companion [X402Client Go package](https://github.com/AceDataCloud/X402Client/tree/main/go).
+
+## Install
+
+```bash
+go get github.com/AceDataCloud/SDK/go@latest
+```
+
+## Quick start
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    acedatacloud "github.com/AceDataCloud/SDK/go"
+)
+
+func main() {
+    client, err := acedatacloud.NewClient(acedatacloud.WithAPIToken("<token>"))
+    if err != nil { panic(err) }
+
+    resp, err := client.OpenAI().Chat().Completions().Create(context.Background(),
+        acedatacloud.ChatCompletionRequest{
+            Model: "gpt-4o-mini",
+            Messages: []map[string]any{
+                {"role": "user", "content": "Say hi in 3 words."},
+            },
+        })
+    if err != nil { panic(err) }
+    fmt.Printf("%+v\n", resp)
+}
+```
+
+If you omit `WithAPIToken`, the SDK reads `ACEDATACLOUD_API_TOKEN` from the
+environment. If that is also empty, you must supply a `PaymentHandler`
+(typically from `x402-client`).
+
+## Streaming
+
+```go
+chunks, errs := client.OpenAI().Chat().Completions().CreateStream(ctx,
+    acedatacloud.ChatCompletionRequest{
+        Model: "gpt-4o-mini",
+        Messages: []map[string]any{{"role": "user", "content": "hi"}},
+    })
+for chunk := range chunks {
+    fmt.Printf("%v\n", chunk)
+}
+if err := <-errs; err != nil { panic(err) }
+```
+
+## Images (task-based)
+
+```go
+handle, _, err := client.Images().Generate(ctx, acedatacloud.ImageGenerateRequest{
+    Prompt:   "a cyberpunk cat",
+    Provider: "nano-banana",
+})
+// Poll until completion (or use handle.Get(ctx) to check once)
+res, err := handle.Wait(ctx, 3*time.Second, 5*time.Minute)
+```
+
+## Paying per request with x402
+
+```go
+import (
+    acedatacloud "github.com/AceDataCloud/SDK/go"
+    x402 "github.com/AceDataCloud/X402Client/go"
+)
+
+signer, _ := x402.NewEVMSignerFromPrivateKey("0x<your-key>")
+handler := x402.NewHandler(x402.HandlerOptions{
+    Network:   "base",
+    EVMSigner: signer,
+})
+
+client, _ := acedatacloud.NewClient(acedatacloud.WithPaymentHandler(handler))
+// Any call to a paid endpoint will be settled on-chain automatically.
+```
+
+## Errors
+
+All API-level errors implement the `Error` interface and are typed:
+
+| Error                      | Condition |
+|----------------------------|-----------|
+| `*AuthenticationError`     | 401 / missing token / expired token |
+| `*RateLimitError`          | 429 |
+| `*ValidationError`         | 400 / bad request |
+| `*InsufficientBalanceError`| code=`used_up` |
+| `*ResourceDisabledError`   | code=`disabled` |
+| `*ModerationError`         | 403 |
+| `*TimeoutError`            | network/task timeout |
+| `*APIError`                | generic catch-all |
+
+Use `errors.As` to type-assert:
+
+```go
+var rl *acedatacloud.RateLimitError
+if errors.As(err, &rl) { /* backoff */ }
+```
+
+## Testing
+
+```bash
+cd go
+go vet ./...
+go test ./...
+```

--- a/go/chat.go
+++ b/go/chat.go
@@ -1,0 +1,69 @@
+package acedatacloud
+
+import "context"
+
+// MessagesRequest is the input to chat.messages.create (native Anthropic shape).
+type MessagesRequest struct {
+	Model     string           `json:"model"`
+	Messages  []map[string]any `json:"messages"`
+	MaxTokens int              `json:"max_tokens"`
+	Stream    bool             `json:"stream,omitempty"`
+	System    string           `json:"system,omitempty"`
+	Extra     map[string]any   `json:"-"`
+}
+
+func (r MessagesRequest) toBody() map[string]any {
+	maxTok := r.MaxTokens
+	if maxTok == 0 {
+		maxTok = 4096
+	}
+	body := map[string]any{
+		"model":      r.Model,
+		"messages":   r.Messages,
+		"max_tokens": maxTok,
+	}
+	if r.Stream {
+		body["stream"] = true
+	}
+	if r.System != "" {
+		body["system"] = r.System
+	}
+	for k, v := range r.Extra {
+		if _, exists := body[k]; !exists {
+			body[k] = v
+		}
+	}
+	return body
+}
+
+// ChatResource groups native chat endpoints.
+type ChatResource struct {
+	t *transport
+}
+
+// Messages returns the messages sub-namespace.
+func (c *ChatResource) Messages() *ChatMessages { return &ChatMessages{t: c.t} }
+
+// ChatMessages exposes ``/v1/messages`` and ``/v1/messages/count_tokens``.
+type ChatMessages struct{ t *transport }
+
+// Create performs a blocking messages.create.
+func (m *ChatMessages) Create(ctx context.Context, req MessagesRequest) (map[string]any, error) {
+	body := req.toBody()
+	delete(body, "stream")
+	return m.t.do(ctx, requestOpts{Method: "POST", Path: "/v1/messages", Body: body})
+}
+
+// CreateStream performs a streaming messages.create.
+func (m *ChatMessages) CreateStream(ctx context.Context, req MessagesRequest) (<-chan map[string]any, <-chan error) {
+	req.Stream = true
+	return streamDecode(m.t, "/v1/messages", req.toBody())
+}
+
+// CountTokens exposes ``/v1/messages/count_tokens``.
+func (m *ChatMessages) CountTokens(ctx context.Context, req MessagesRequest) (map[string]any, error) {
+	body := req.toBody()
+	delete(body, "stream")
+	delete(body, "max_tokens")
+	return m.t.do(ctx, requestOpts{Method: "POST", Path: "/v1/messages/count_tokens", Body: body})
+}

--- a/go/client.go
+++ b/go/client.go
@@ -1,0 +1,48 @@
+package acedatacloud
+
+// Client is the top-level AceDataCloud SDK client.
+//
+// It exposes domain-specific resource groups via accessor methods,
+// mirroring the Python ``AceDataCloud`` class and the TypeScript
+// ``AceDataCloud`` class.
+type Client struct {
+	transport *transport
+
+	openai *OpenAIResource
+	chat   *ChatResource
+	images *ImagesResource
+	tasks  *TasksResource
+}
+
+// NewClient constructs a Client. At least one of WithAPIToken /
+// ACEDATACLOUD_API_TOKEN env var / WithPaymentHandler must be provided.
+func NewClient(opts ...Option) (*Client, error) {
+	o := defaultOptions()
+	for _, fn := range opts {
+		fn(o)
+	}
+	tr, err := newTransport(o)
+	if err != nil {
+		return nil, err
+	}
+	c := &Client{transport: tr}
+	c.openai = &OpenAIResource{t: tr}
+	c.chat = &ChatResource{t: tr}
+	c.images = &ImagesResource{t: tr}
+	c.tasks = &TasksResource{t: tr}
+	return c, nil
+}
+
+// OpenAI returns the OpenAI-compatible resource (``/v1/chat/completions``,
+// ``/openai/responses``).
+func (c *Client) OpenAI() *OpenAIResource { return c.openai }
+
+// Chat returns the native chat resource (``/v1/messages`` — Anthropic
+// Messages API shape).
+func (c *Client) Chat() *ChatResource { return c.chat }
+
+// Images returns the image generation resource.
+func (c *Client) Images() *ImagesResource { return c.images }
+
+// Tasks returns the cross-service task retrieval resource.
+func (c *Client) Tasks() *TasksResource { return c.tasks }

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -1,0 +1,256 @@
+package acedatacloud
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewClient_RequiresTokenOrHandler(t *testing.T) {
+	t.Setenv("ACEDATACLOUD_API_TOKEN", "")
+	_, err := NewClient()
+	if err == nil {
+		t.Fatal("expected error when no token and no payment handler")
+	}
+	if _, ok := err.(*AuthenticationError); !ok {
+		t.Fatalf("expected AuthenticationError, got %T", err)
+	}
+}
+
+func TestNewClient_WithToken(t *testing.T) {
+	c, err := NewClient(WithAPIToken("test-token"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c.OpenAI() == nil || c.Chat() == nil || c.Images() == nil || c.Tasks() == nil {
+		t.Fatal("resources must be non-nil")
+	}
+}
+
+func TestChatCompletions_Create(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/chat/completions" {
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer token-abc" {
+			t.Errorf("missing auth header")
+		}
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["model"] != "gpt-4o-mini" {
+			t.Errorf("bad model: %v", body["model"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"c1","choices":[{"message":{"role":"assistant","content":"hi"}}]}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(WithAPIToken("token-abc"), WithBaseURL(srv.URL))
+	res, err := c.OpenAI().Chat().Completions().Create(context.Background(), ChatCompletionRequest{
+		Model:    "gpt-4o-mini",
+		Messages: []map[string]any{{"role": "user", "content": "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if res["id"] != "c1" {
+		t.Fatalf("bad response: %+v", res)
+	}
+}
+
+func TestTransport_RetriesOn503(t *testing.T) {
+	attempts := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 2 {
+			w.WriteHeader(503)
+			_, _ = w.Write([]byte(`{"error":{"code":"unknown","message":"busy"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(WithAPIToken("t"), WithBaseURL(srv.URL), WithMaxRetries(3))
+	res, err := c.OpenAI().Chat().Completions().Create(context.Background(), ChatCompletionRequest{
+		Model:    "m",
+		Messages: []map[string]any{{"role": "user", "content": "x"}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res["ok"] != true {
+		t.Fatalf("bad response: %+v", res)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestTransport_MapErrorNon401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		_, _ = w.Write([]byte(`{"error":{"code":"too_many_requests","message":"slow down"},"trace_id":"abc"}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(WithAPIToken("t"), WithBaseURL(srv.URL), WithMaxRetries(0))
+	_, err := c.OpenAI().Chat().Completions().Create(context.Background(), ChatCompletionRequest{
+		Model:    "m",
+		Messages: []map[string]any{{"role": "user", "content": "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	rl, ok := err.(*RateLimitError)
+	if !ok {
+		t.Fatalf("expected RateLimitError, got %T: %v", err, err)
+	}
+	if rl.TraceID() != "abc" {
+		t.Errorf("missing trace_id: %+v", rl)
+	}
+}
+
+func TestTransport_MapErrorWithStringBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(402)
+		_, _ = w.Write([]byte(`{"error":"insufficient payment"}`))
+	}))
+	defer srv.Close()
+
+	// No payment handler, so 402 is raised as a plain error.
+	c, _ := NewClient(WithAPIToken("t"), WithBaseURL(srv.URL), WithMaxRetries(0))
+	_, err := c.OpenAI().Chat().Completions().Create(context.Background(), ChatCompletionRequest{
+		Model:    "m",
+		Messages: []map[string]any{{"role": "user", "content": "x"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.Message != "insufficient payment" {
+		t.Errorf("bad message: %q", apiErr.Message)
+	}
+}
+
+func TestPaymentHandler_OnSecond402ThenSuccess(t *testing.T) {
+	hit := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit++
+		if hit == 1 {
+			if r.Header.Get("X-Payment") != "" {
+				t.Errorf("first request should not have X-Payment")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(402)
+			_, _ = w.Write([]byte(`{"x402Version":2,"accepts":[{"network":"base","scheme":"exact","payTo":"0xabc","asset":"0xusdc","maxAmountRequired":"100"}]}`))
+			return
+		}
+		if got := r.Header.Get("X-Payment"); got != "fake-envelope" {
+			t.Errorf("expected X-Payment=fake-envelope, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"paid":true}`))
+	}))
+	defer srv.Close()
+
+	var received PaymentContext
+	handler := PaymentHandlerFunc(func(ctx context.Context, pctx PaymentContext) (PaymentResult, error) {
+		received = pctx
+		return PaymentResult{Headers: map[string]string{"X-Payment": "fake-envelope"}}, nil
+	})
+
+	c, _ := NewClient(WithBaseURL(srv.URL), WithPaymentHandler(handler))
+	res, err := c.OpenAI().Chat().Completions().Create(context.Background(), ChatCompletionRequest{
+		Model:    "m",
+		Messages: []map[string]any{{"role": "user", "content": "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if res["paid"] != true {
+		t.Fatalf("bad response: %+v", res)
+	}
+	if len(received.Accepts) != 1 || received.Accepts[0]["network"] != "base" {
+		t.Fatalf("payment context not propagated: %+v", received)
+	}
+	if hit != 2 {
+		t.Fatalf("expected 2 hits, got %d", hit)
+	}
+}
+
+func TestTaskHandle_WaitCompletes(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		b, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(b), `"id":"t123"`) {
+			t.Errorf("bad body: %s", b)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if calls < 3 {
+			_, _ = w.Write([]byte(`{"response":{"status":"processing"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"response":{"status":"succeeded","url":"https://cdn.example/f.png"}}`))
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(WithAPIToken("t"), WithBaseURL(srv.URL))
+	res, err := c.Tasks().Wait(context.Background(), "suno", "t123", 10*time.Millisecond, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	resp := res["response"].(map[string]any)
+	if resp["status"] != "succeeded" {
+		t.Fatalf("bad status: %+v", resp)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 polls, got %d", calls)
+	}
+}
+
+func TestImages_GenerateReturnsTaskHandle(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/nano-banana/images" {
+			_, _ = w.Write([]byte(`{"task_id":"img-1"}`))
+			return
+		}
+		if r.URL.Path == "/nano-banana/tasks" {
+			_, _ = w.Write([]byte(`{"response":{"status":"succeeded","url":"https://cdn/x.png"}}`))
+			return
+		}
+		t.Errorf("unexpected path %s", r.URL.Path)
+	}))
+	defer srv.Close()
+
+	c, _ := NewClient(WithAPIToken("t"), WithBaseURL(srv.URL))
+	handle, _, err := c.Images().Generate(context.Background(), ImageGenerateRequest{
+		Prompt:   "a cat",
+		Provider: "nano-banana",
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if handle == nil || handle.ID != "img-1" {
+		t.Fatalf("expected task handle with id=img-1, got %+v", handle)
+	}
+	res, err := handle.Wait(context.Background(), 5*time.Millisecond, 1*time.Second)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	resp := res["response"].(map[string]any)
+	if resp["url"] != "https://cdn/x.png" {
+		t.Fatalf("bad url: %+v", resp)
+	}
+}

--- a/go/doc.go
+++ b/go/doc.go
@@ -1,0 +1,26 @@
+// Package acedatacloud is the official Go SDK for the AceDataCloud API.
+//
+// It mirrors the design of the Python and TypeScript SDKs:
+//
+//   - A top-level Client with pluggable options.
+//   - Domain resources: OpenAI (chat/responses), Chat (native messages),
+//     Images, Tasks.
+//   - Automatic retries with exponential backoff + jitter.
+//   - Task polling via TaskHandle for long-running generation jobs.
+//   - A pluggable PaymentHandler hook that is invoked on 402 Payment
+//     Required, enabling on-chain x402 USDC payments via a companion
+//     package.
+//
+// Basic usage:
+//
+//	client := acedatacloud.NewClient(acedatacloud.WithAPIToken("..."))
+//	resp, err := client.OpenAI().Chat().Completions().Create(
+//	    context.Background(),
+//	    acedatacloud.ChatCompletionRequest{
+//	        Model:    "gpt-4o-mini",
+//	        Messages: []map[string]any{{"role": "user", "content": "hi"}},
+//	    },
+//	)
+//
+// See README.md for the full guide.
+package acedatacloud

--- a/go/errors.go
+++ b/go/errors.go
@@ -1,0 +1,104 @@
+package acedatacloud
+
+import "fmt"
+
+// Error is the base interface for all typed SDK errors.
+type Error interface {
+	error
+	StatusCode() int
+	Code() string
+	TraceID() string
+	Body() map[string]any
+}
+
+// APIError is returned for API-level errors.
+type APIError struct {
+	Message    string
+	Status     int
+	ErrCode    string
+	Trace      string
+	RawBody    map[string]any
+	Underlying error
+}
+
+func (e *APIError) Error() string {
+	if e.Trace != "" {
+		return fmt.Sprintf("acedatacloud: %s (status=%d code=%s trace_id=%s)", e.Message, e.Status, e.ErrCode, e.Trace)
+	}
+	return fmt.Sprintf("acedatacloud: %s (status=%d code=%s)", e.Message, e.Status, e.ErrCode)
+}
+
+func (e *APIError) Unwrap() error         { return e.Underlying }
+func (e *APIError) StatusCode() int       { return e.Status }
+func (e *APIError) Code() string          { return e.ErrCode }
+func (e *APIError) TraceID() string       { return e.Trace }
+func (e *APIError) Body() map[string]any  { return e.RawBody }
+
+// Typed error wrappers. All embed *APIError.
+type (
+	AuthenticationError     struct{ *APIError }
+	TokenMismatchError      struct{ *APIError }
+	PermissionError         struct{ *APIError }
+	RateLimitError          struct{ *APIError }
+	ValidationError         struct{ *APIError }
+	InsufficientBalanceError struct{ *APIError }
+	ResourceDisabledError   struct{ *APIError }
+	ModerationError         struct{ *APIError }
+	TimeoutError            struct{ *APIError }
+	InternalServerError     struct{ *APIError }
+	TransportError          struct{ *APIError }
+)
+
+// mapError converts an HTTP status code + parsed body into a typed error.
+func mapError(status int, body map[string]any) error {
+	var (
+		code    string
+		message string
+		trace   string
+	)
+	trace, _ = body["trace_id"].(string)
+
+	// "error" may be a dict, string, or missing — normalize.
+	switch v := body["error"].(type) {
+	case map[string]any:
+		code, _ = v["code"].(string)
+		message, _ = v["message"].(string)
+	case string:
+		message = v
+	}
+
+	base := &APIError{
+		Message: message,
+		Status:  status,
+		ErrCode: code,
+		Trace:   trace,
+		RawBody: body,
+	}
+
+	switch code {
+	case "invalid_token", "token_expired", "no_token":
+		return &AuthenticationError{base}
+	case "token_mismatched":
+		return &TokenMismatchError{base}
+	case "used_up":
+		return &InsufficientBalanceError{base}
+	case "disabled":
+		return &ResourceDisabledError{base}
+	case "too_many_requests":
+		return &RateLimitError{base}
+	case "bad_request":
+		return &ValidationError{base}
+	}
+
+	switch status {
+	case 401:
+		return &AuthenticationError{base}
+	case 403:
+		return &ModerationError{base}
+	case 429:
+		return &RateLimitError{base}
+	case 400:
+		return &ValidationError{base}
+	}
+	return base
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/AceDataCloud/SDK/go
+
+go 1.21

--- a/go/images.go
+++ b/go/images.go
@@ -1,0 +1,80 @@
+package acedatacloud
+
+import "context"
+
+// ImageGenerateRequest is the input to images.generate.
+type ImageGenerateRequest struct {
+	// Prompt is the required text prompt.
+	Prompt string
+	// Provider selects the backend. Common values: "nano-banana",
+	// "midjourney", "flux", "seedream".
+	Provider string
+	// Model is optional — provider-specific model identifier.
+	Model string
+	// NegativePrompt is optional.
+	NegativePrompt string
+	// ImageURL is optional reference image.
+	ImageURL string
+	// CallbackURL optionally receives the task completion webhook.
+	CallbackURL string
+	// Extra fields merged into the request body.
+	Extra map[string]any
+}
+
+func (r ImageGenerateRequest) toBody() map[string]any {
+	body := map[string]any{"prompt": r.Prompt}
+	if r.Model != "" {
+		body["model"] = r.Model
+	}
+	if r.NegativePrompt != "" {
+		body["negative_prompt"] = r.NegativePrompt
+	}
+	if r.ImageURL != "" {
+		body["image_url"] = r.ImageURL
+	}
+	if r.CallbackURL != "" {
+		body["callback_url"] = r.CallbackURL
+	}
+	for k, v := range r.Extra {
+		if _, exists := body[k]; !exists {
+			body[k] = v
+		}
+	}
+	return body
+}
+
+// ImagesResource groups image-generation endpoints.
+type ImagesResource struct{ t *transport }
+
+// Generate enqueues an image-generation task. It returns a TaskHandle
+// (for polling) when the server responds asynchronously, or the direct
+// result map when the server produced the image synchronously.
+//
+// If both a TaskHandle and a direct result are in-scope, prefer the
+// TaskHandle when ``req.Provider != ""`` and the server returned a
+// ``task_id``.
+func (i *ImagesResource) Generate(ctx context.Context, req ImageGenerateRequest) (*TaskHandle, map[string]any, error) {
+	provider := req.Provider
+	if provider == "" {
+		provider = "nano-banana"
+	}
+	endpoint := "/" + provider + "/images"
+	if provider == "midjourney" {
+		endpoint = "/midjourney/imagine"
+	}
+	body := req.toBody()
+	result, err := i.t.do(ctx, requestOpts{Method: "POST", Path: endpoint, Body: body})
+	if err != nil {
+		return nil, nil, err
+	}
+	taskID, _ := result["task_id"].(string)
+	if taskID == "" {
+		return nil, result, nil
+	}
+	handle := &TaskHandle{
+		ID:           taskID,
+		pollEndpoint: "/" + provider + "/tasks",
+		transport:    i.t,
+	}
+	return handle, result, nil
+}

--- a/go/openai.go
+++ b/go/openai.go
@@ -1,0 +1,152 @@
+package acedatacloud
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ChatCompletionRequest is the input to OpenAI chat.completions.create.
+//
+// The struct exposes the common fields explicitly and an ``Extra`` map
+// for forward-compatible fields (tools, response_format, etc.).
+type ChatCompletionRequest struct {
+	Model       string           `json:"model"`
+	Messages    []map[string]any `json:"messages"`
+	Stream      bool             `json:"stream,omitempty"`
+	MaxTokens   int              `json:"max_tokens,omitempty"`
+	Temperature *float64         `json:"temperature,omitempty"`
+	TopP        *float64         `json:"top_p,omitempty"`
+
+	// Extra is merged into the request body. Keys here take precedence
+	// over nothing — they are only added if the explicit field is zero.
+	Extra map[string]any `json:"-"`
+}
+
+func (r ChatCompletionRequest) toBody() map[string]any {
+	body := map[string]any{
+		"model":    r.Model,
+		"messages": r.Messages,
+	}
+	if r.Stream {
+		body["stream"] = true
+	}
+	if r.MaxTokens > 0 {
+		body["max_tokens"] = r.MaxTokens
+	}
+	if r.Temperature != nil {
+		body["temperature"] = *r.Temperature
+	}
+	if r.TopP != nil {
+		body["top_p"] = *r.TopP
+	}
+	for k, v := range r.Extra {
+		if _, exists := body[k]; !exists {
+			body[k] = v
+		}
+	}
+	return body
+}
+
+// ResponsesRequest is the input to OpenAI responses.create.
+type ResponsesRequest struct {
+	Model  string         `json:"model"`
+	Input  any            `json:"input"`
+	Stream bool           `json:"stream,omitempty"`
+	Extra  map[string]any `json:"-"`
+}
+
+func (r ResponsesRequest) toBody() map[string]any {
+	body := map[string]any{"model": r.Model, "input": r.Input}
+	if r.Stream {
+		body["stream"] = true
+	}
+	for k, v := range r.Extra {
+		if _, exists := body[k]; !exists {
+			body[k] = v
+		}
+	}
+	return body
+}
+
+// OpenAIResource groups the OpenAI-compatible endpoints.
+type OpenAIResource struct {
+	t *transport
+}
+
+// Chat returns the chat sub-namespace.
+func (o *OpenAIResource) Chat() *OpenAIChat { return &OpenAIChat{t: o.t} }
+
+// Responses returns the responses sub-namespace.
+func (o *OpenAIResource) Responses() *OpenAIResponses { return &OpenAIResponses{t: o.t} }
+
+// OpenAIChat exposes ``/v1/chat/completions``.
+type OpenAIChat struct{ t *transport }
+
+// Completions returns the completions sub-namespace.
+func (c *OpenAIChat) Completions() *OpenAIChatCompletions { return &OpenAIChatCompletions{t: c.t} }
+
+// OpenAIChatCompletions exposes chat.completions.create.
+type OpenAIChatCompletions struct{ t *transport }
+
+// Create performs a blocking (non-streaming) chat completion.
+func (c *OpenAIChatCompletions) Create(ctx context.Context, req ChatCompletionRequest) (map[string]any, error) {
+	body := req.toBody()
+	delete(body, "stream")
+	return c.t.do(ctx, requestOpts{Method: "POST", Path: "/v1/chat/completions", Body: body})
+}
+
+// CreateStream performs a streaming chat completion and returns a
+// channel of decoded chunks (each a ``map[string]any`` parsed from a
+// single SSE ``data:`` line).
+func (c *OpenAIChatCompletions) CreateStream(ctx context.Context, req ChatCompletionRequest) (<-chan map[string]any, <-chan error) {
+	req.Stream = true
+	return streamDecode(c.t, "/v1/chat/completions", req.toBody())
+}
+
+// OpenAIResponses exposes ``/openai/responses``.
+type OpenAIResponses struct{ t *transport }
+
+// Create performs a blocking responses.create.
+func (r *OpenAIResponses) Create(ctx context.Context, req ResponsesRequest) (map[string]any, error) {
+	body := req.toBody()
+	delete(body, "stream")
+	return r.t.do(ctx, requestOpts{Method: "POST", Path: "/openai/responses", Body: body})
+}
+
+// CreateStream performs a streaming responses.create.
+func (r *OpenAIResponses) CreateStream(ctx context.Context, req ResponsesRequest) (<-chan map[string]any, <-chan error) {
+	req.Stream = true
+	return streamDecode(r.t, "/openai/responses", req.toBody())
+}
+
+// streamDecode wraps transport.stream and parses each SSE data line as JSON.
+func streamDecode(t *transport, path string, body any) (<-chan map[string]any, <-chan error) {
+	raw, rawErr := t.stream(context.Background(), path, body)
+	out := make(chan map[string]any)
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(out)
+		defer close(errCh)
+		for {
+			select {
+			case chunk, ok := <-raw:
+				if !ok {
+					return
+				}
+				parsed := map[string]any{}
+				if err := json.Unmarshal(chunk, &parsed); err == nil {
+					out <- parsed
+				}
+			case err, ok := <-rawErr:
+				if ok && err != nil {
+					errCh <- err
+					return
+				}
+				if !ok {
+					return
+				}
+			}
+		}
+	}()
+	return out, errCh
+}

--- a/go/options.go
+++ b/go/options.go
@@ -1,0 +1,73 @@
+package acedatacloud
+
+import (
+	"net/http"
+	"time"
+)
+
+const (
+	defaultAPIBase      = "https://api.acedata.cloud"
+	defaultPlatformBase = "https://platform.acedata.cloud"
+	defaultTimeout      = 300 * time.Second
+	defaultMaxRetries   = 2
+	userAgent           = "acedatacloud-go/0.1.0"
+)
+
+// Option configures a Client.
+type Option func(*options)
+
+type options struct {
+	apiToken       string
+	baseURL        string
+	platformURL    string
+	timeout        time.Duration
+	maxRetries     int
+	extraHeaders   map[string]string
+	paymentHandler PaymentHandler
+	httpClient     *http.Client
+}
+
+func defaultOptions() *options {
+	return &options{
+		baseURL:      defaultAPIBase,
+		platformURL:  defaultPlatformBase,
+		timeout:      defaultTimeout,
+		maxRetries:   defaultMaxRetries,
+		extraHeaders: map[string]string{},
+	}
+}
+
+// WithAPIToken sets the Bearer token. If omitted, the SDK reads
+// ``ACEDATACLOUD_API_TOKEN`` from the environment.
+func WithAPIToken(token string) Option { return func(o *options) { o.apiToken = token } }
+
+// WithBaseURL overrides the API gateway base URL.
+func WithBaseURL(url string) Option { return func(o *options) { o.baseURL = url } }
+
+// WithPlatformURL overrides the management plane base URL.
+func WithPlatformURL(url string) Option { return func(o *options) { o.platformURL = url } }
+
+// WithTimeout sets the per-request timeout.
+func WithTimeout(d time.Duration) Option { return func(o *options) { o.timeout = d } }
+
+// WithMaxRetries sets the number of retry attempts for transient errors.
+func WithMaxRetries(n int) Option { return func(o *options) { o.maxRetries = n } }
+
+// WithHeaders adds static headers to every request.
+func WithHeaders(h map[string]string) Option {
+	return func(o *options) {
+		for k, v := range h {
+			o.extraHeaders[k] = v
+		}
+	}
+}
+
+// WithPaymentHandler installs a handler invoked on 402 Payment Required.
+func WithPaymentHandler(h PaymentHandler) Option {
+	return func(o *options) { o.paymentHandler = h }
+}
+
+// WithHTTPClient overrides the underlying *http.Client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(o *options) { o.httpClient = c }
+}

--- a/go/payment.go
+++ b/go/payment.go
@@ -1,0 +1,41 @@
+package acedatacloud
+
+import "context"
+
+// PaymentRequirement describes a single entry in the server's 402 ``accepts`` list.
+//
+// Using map[string]any keeps the SDK free of chain-specific types — the
+// companion x402-client package is responsible for interpreting the
+// ``extra`` field and producing an ``X-Payment`` envelope.
+type PaymentRequirement = map[string]any
+
+// PaymentContext is passed to a PaymentHandler when the transport
+// receives a 402 Payment Required response.
+type PaymentContext struct {
+	URL     string
+	Method  string
+	Body    any
+	Accepts []PaymentRequirement
+}
+
+// PaymentResult is what a PaymentHandler must return: the headers to
+// attach to the retried request (typically ``X-Payment``).
+type PaymentResult struct {
+	Headers map[string]string
+}
+
+// PaymentHandler is the hook the SDK calls on 402. Implementations
+// typically sign an EIP-3009 authorization (EVM) or submit a
+// TransferChecked transaction (Solana) and return an ``X-Payment``
+// header.
+type PaymentHandler interface {
+	Handle(ctx context.Context, pctx PaymentContext) (PaymentResult, error)
+}
+
+// PaymentHandlerFunc adapts a plain function into a PaymentHandler.
+type PaymentHandlerFunc func(ctx context.Context, pctx PaymentContext) (PaymentResult, error)
+
+// Handle implements PaymentHandler.
+func (f PaymentHandlerFunc) Handle(ctx context.Context, pctx PaymentContext) (PaymentResult, error) {
+	return f(ctx, pctx)
+}

--- a/go/tasks.go
+++ b/go/tasks.go
@@ -1,0 +1,85 @@
+package acedatacloud
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// TaskHandle represents a long-running async task (image/audio/video
+// generation) that can be polled until completion.
+type TaskHandle struct {
+	ID           string
+	pollEndpoint string
+	transport    *transport
+	last         map[string]any
+}
+
+// Get fetches the current task state from the server.
+func (h *TaskHandle) Get(ctx context.Context) (map[string]any, error) {
+	state, err := h.transport.do(ctx, requestOpts{
+		Method: "POST",
+		Path:   h.pollEndpoint,
+		Body:   map[string]any{"id": h.ID, "action": "retrieve"},
+	})
+	if err != nil {
+		return nil, err
+	}
+	h.last = state
+	return state, nil
+}
+
+// IsCompleted reports whether the task has reached a terminal state
+// (``succeeded`` or ``failed``). Returns true together with the error
+// if the network call fails.
+func (h *TaskHandle) IsCompleted(ctx context.Context) (bool, error) {
+	state, err := h.Get(ctx)
+	if err != nil {
+		return false, err
+	}
+	return terminalStatus(state), nil
+}
+
+// Result returns the last observed server response, or nil if Get was
+// never called.
+func (h *TaskHandle) Result() map[string]any { return h.last }
+
+// Wait polls until the task completes or maxWait elapses.
+func (h *TaskHandle) Wait(ctx context.Context, pollInterval, maxWait time.Duration) (map[string]any, error) {
+	if pollInterval <= 0 {
+		pollInterval = 3 * time.Second
+	}
+	if maxWait <= 0 {
+		maxWait = 10 * time.Minute
+	}
+	deadline := time.Now().Add(maxWait)
+	for {
+		state, err := h.Get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if terminalStatus(state) {
+			return state, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, &TimeoutError{&APIError{
+				Message: fmt.Sprintf("task %s did not complete within %s", h.ID, maxWait),
+				ErrCode: "task_timeout",
+			}}
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+func terminalStatus(state map[string]any) bool {
+	resp := state
+	if r, ok := state["response"].(map[string]any); ok {
+		resp = r
+	}
+	status, _ := resp["status"].(string)
+	return status == "succeeded" || status == "failed"
+}

--- a/go/tasks_resource.go
+++ b/go/tasks_resource.go
@@ -1,0 +1,55 @@
+package acedatacloud
+
+import (
+	"context"
+	"time"
+)
+
+var serviceTaskEndpoints = map[string]string{
+	"suno":        "/suno/tasks",
+	"producer":    "/producer/tasks",
+	"fish":        "/fish/tasks",
+	"nano-banana": "/nano-banana/tasks",
+	"seedream":    "/seedream/tasks",
+	"seedance":    "/seedance/tasks",
+	"sora":        "/sora/tasks",
+	"midjourney":  "/midjourney/tasks",
+	"luma":        "/luma/tasks",
+	"veo":         "/veo/tasks",
+	"flux":        "/flux/tasks",
+	"kling":       "/kling/tasks",
+	"hailuo":      "/hailuo/tasks",
+	"wan":         "/wan/tasks",
+	"pika":        "/pika/tasks",
+	"pixverse":    "/pixverse/tasks",
+}
+
+// TasksResource groups cross-service task retrieval operations.
+type TasksResource struct{ t *transport }
+
+// Get fetches a single task snapshot.
+func (r *TasksResource) Get(ctx context.Context, service, taskID string) (map[string]any, error) {
+	endpoint := endpointFor(service)
+	return r.t.do(ctx, requestOpts{
+		Method: "POST",
+		Path:   endpoint,
+		Body:   map[string]any{"id": taskID, "action": "retrieve"},
+	})
+}
+
+// Wait polls a task until it reaches a terminal state or maxWait elapses.
+func (r *TasksResource) Wait(ctx context.Context, service, taskID string, pollInterval, maxWait time.Duration) (map[string]any, error) {
+	handle := &TaskHandle{
+		ID:           taskID,
+		pollEndpoint: endpointFor(service),
+		transport:    r.t,
+	}
+	return handle.Wait(ctx, pollInterval, maxWait)
+}
+
+func endpointFor(service string) string {
+	if ep, ok := serviceTaskEndpoints[service]; ok {
+		return ep
+	}
+	return "/" + service + "/tasks"
+}

--- a/go/transport.go
+++ b/go/transport.go
@@ -1,0 +1,274 @@
+package acedatacloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Transport performs authenticated HTTP requests to the AceDataCloud API.
+type transport struct {
+	opts       *options
+	httpClient *http.Client
+	headers    map[string]string
+}
+
+var retryStatus = map[int]bool{408: true, 409: true, 429: true, 500: true, 502: true, 503: true, 504: true}
+
+func newTransport(opts *options) (*transport, error) {
+	token := opts.apiToken
+	if token == "" {
+		token = os.Getenv("ACEDATACLOUD_API_TOKEN")
+	}
+	if token == "" && opts.paymentHandler == nil {
+		return nil, &AuthenticationError{&APIError{
+			Message: "api_token is required (or provide a PaymentHandler). Pass WithAPIToken or set ACEDATACLOUD_API_TOKEN.",
+			ErrCode: "no_token",
+		}}
+	}
+
+	client := opts.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: opts.timeout}
+	}
+
+	h := map[string]string{
+		"Accept":       "application/json",
+		"Content-Type": "application/json",
+		"User-Agent":   userAgent,
+	}
+	for k, v := range opts.extraHeaders {
+		h[k] = v
+	}
+	if token != "" {
+		h["Authorization"] = "Bearer " + token
+	}
+
+	return &transport{opts: opts, httpClient: client, headers: h}, nil
+}
+
+// requestOpts describes a single API call.
+type requestOpts struct {
+	Method       string
+	Path         string
+	Body         any
+	Query        url.Values
+	Platform     bool
+	ExtraHeaders map[string]string
+}
+
+func backoff(attempt int) time.Duration {
+	base := math.Min(math.Pow(2, float64(attempt)), 8)
+	//nolint:gosec // non-crypto jitter
+	jitter := rand.Float64() * 0.5
+	return time.Duration((base + jitter) * float64(time.Second))
+}
+
+// do executes a JSON request and parses a JSON map response.
+func (t *transport) do(ctx context.Context, r requestOpts) (map[string]any, error) {
+	base := t.opts.baseURL
+	if r.Platform {
+		base = t.opts.platformURL
+	}
+	fullURL := base + r.Path
+	if len(r.Query) > 0 {
+		fullURL += "?" + r.Query.Encode()
+	}
+
+	var bodyBytes []byte
+	if r.Body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(r.Body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal body: %w", err)
+		}
+	}
+
+	extraAuth := map[string]string{}
+	paymentAttempted := false
+
+	var lastErr error
+	for attempt := 0; attempt <= t.opts.maxRetries; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, r.Method, fullURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		for k, v := range t.headers {
+			req.Header.Set(k, v)
+		}
+		for k, v := range r.ExtraHeaders {
+			req.Header.Set(k, v)
+		}
+		for k, v := range extraAuth {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := t.httpClient.Do(req)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, &TimeoutError{&APIError{Message: err.Error(), ErrCode: "timeout"}}
+			}
+			lastErr = &TransportError{&APIError{Message: err.Error()}}
+			if attempt < t.opts.maxRetries {
+				time.Sleep(backoff(attempt))
+				continue
+			}
+			return nil, lastErr
+		}
+
+		respBody, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		// Handle 402 Payment Required: invoke handler once, then retry with new headers.
+		if resp.StatusCode == http.StatusPaymentRequired && t.opts.paymentHandler != nil && !paymentAttempted {
+			var parsed map[string]any
+			if err := json.Unmarshal(respBody, &parsed); err != nil {
+				return nil, mapError(402, map[string]any{"error": map[string]any{"code": "invalid_402", "message": string(respBody)}})
+			}
+			rawAccepts, _ := parsed["accepts"].([]any)
+			if len(rawAccepts) == 0 {
+				return nil, mapError(402, map[string]any{"error": map[string]any{"code": "invalid_402", "message": "No payment requirements"}})
+			}
+			accepts := make([]PaymentRequirement, 0, len(rawAccepts))
+			for _, a := range rawAccepts {
+				if m, ok := a.(map[string]any); ok {
+					accepts = append(accepts, m)
+				}
+			}
+			pctx := PaymentContext{URL: fullURL, Method: r.Method, Body: r.Body, Accepts: accepts}
+			result, err := t.opts.paymentHandler.Handle(ctx, pctx)
+			if err != nil {
+				return nil, fmt.Errorf("payment handler: %w", err)
+			}
+			for k, v := range result.Headers {
+				extraAuth[k] = v
+			}
+			paymentAttempted = true
+			continue
+		}
+
+		if resp.StatusCode >= 400 {
+			parsed := map[string]any{}
+			if err := json.Unmarshal(respBody, &parsed); err != nil {
+				parsed = map[string]any{"error": map[string]any{"code": "unknown", "message": string(respBody)}}
+			}
+			if retryStatus[resp.StatusCode] && attempt < t.opts.maxRetries {
+				time.Sleep(backoff(attempt))
+				continue
+			}
+			return nil, mapError(resp.StatusCode, parsed)
+		}
+
+		parsed := map[string]any{}
+		if len(respBody) > 0 {
+			if err := json.Unmarshal(respBody, &parsed); err != nil {
+				return nil, fmt.Errorf("parse response: %w", err)
+			}
+		}
+		return parsed, nil
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, &TransportError{&APIError{Message: "request failed after retries"}}
+}
+
+// stream executes a POST and yields SSE data chunks via the returned channel.
+// The channel is closed when the stream ends or an error occurs; errors are
+// reported via the returned error channel.
+func (t *transport) stream(ctx context.Context, path string, body any) (<-chan []byte, <-chan error) {
+	out := make(chan []byte)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(out)
+		defer close(errCh)
+
+		fullURL := t.opts.baseURL + path
+		var bodyBytes []byte
+		if body != nil {
+			var err error
+			bodyBytes, err = json.Marshal(body)
+			if err != nil {
+				errCh <- err
+				return
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(bodyBytes))
+		if err != nil {
+			errCh <- err
+			return
+		}
+		for k, v := range t.headers {
+			req.Header.Set(k, v)
+		}
+		req.Header.Set("Accept", "text/event-stream")
+
+		resp, err := t.httpClient.Do(req)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode >= 400 {
+			respBody, _ := io.ReadAll(resp.Body)
+			parsed := map[string]any{}
+			if e := json.Unmarshal(respBody, &parsed); e != nil {
+				parsed = map[string]any{"error": map[string]any{"code": "unknown", "message": string(respBody)}}
+			}
+			errCh <- mapError(resp.StatusCode, parsed)
+			return
+		}
+
+		reader := resp.Body
+		buf := make([]byte, 0, 4096)
+		tmp := make([]byte, 4096)
+		for {
+			n, err := reader.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+				for {
+					idx := bytes.IndexByte(buf, '\n')
+					if idx < 0 {
+						break
+					}
+					line := strings.TrimRight(string(buf[:idx]), "\r")
+					buf = buf[idx+1:]
+					if !strings.HasPrefix(line, "data: ") {
+						continue
+					}
+					data := strings.TrimPrefix(line, "data: ")
+					if data == "[DONE]" {
+						return
+					}
+					select {
+					case out <- []byte(data):
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			if err != nil {
+				if err != io.EOF {
+					errCh <- err
+				}
+				return
+			}
+		}
+	}()
+
+	return out, errCh
+}


### PR DESCRIPTION
## Summary

Add an official Go SDK at `go/` mirroring the designs of the existing Python and TypeScript SDKs.

## What's in it

- **Client** with functional options (`WithAPIToken`, `WithBaseURL`, `WithPaymentHandler`, `WithTimeout`, `WithMaxRetries`, `WithHeaders`, `WithHTTPClient`)
- **Resources**
  - `OpenAI` → `Chat().Completions().Create` / `CreateStream`, `Responses().Create` / `CreateStream`
  - `Chat` → `Messages().Create` / `CreateStream` / `CountTokens`
  - `Images` → `Generate` (returns a `*TaskHandle` for polling)
  - `Tasks` → `Get` / `Wait` across ~16 services
- **Transport** — exponential-backoff retry on 408/409/429/5xx, parses typed errors from `error.code`
- **TaskHandle.Wait** — polls until `response.status` is `succeeded` or `failed`
- **PaymentHandler** hook — invoked on `402 Payment Required` (integration point for the companion [X402Client Go package](https://github.com/AceDataCloud/X402Client/tree/main/go))
- **Typed errors** — `*AuthenticationError`, `*RateLimitError`, `*ValidationError`, `*InsufficientBalanceError`, `*ResourceDisabledError`, `*ModerationError`, `*TimeoutError`, `*TransportError`

## Module

`github.com/AceDataCloud/SDK/go`, Go 1.21+, tag-based releases (no third-party registry).

## Testing

```
cd go
go vet ./...
go test ./... -race -count=1
```

Unit tests cover: client construction, 503 retry, typed error mapping, string-shaped 402 error body, 402 → PaymentHandler → retry-with-X-Payment flow, TaskHandle.Wait polling, Images.Generate → TaskHandle wiring.

## CI

New `.github/workflows/go.yaml` runs Go 1.21 / 1.22 / 1.23 matrix with race detector.

## Release

After merge, tag `go/v0.1.0` (Go modules expect `<subdir>/vX.Y.Z` for nested modules) so `go get github.com/AceDataCloud/SDK/go@v0.1.0` resolves.
