### PR TITLE
test: align Python SDK OpenAI compat mock endpoints

### DIFF
--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -45,7 +45,7 @@ def test_openai_chat_completions(client):
         ],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
-    respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
+    respx.post("https://api.acedata.cloud/openai/chat/completions").mock(
         return_value=httpx.Response(200, json=mock_response)
     )
 
@@ -269,7 +269,7 @@ def test_platform_config_get(client):
 
 @respx.mock
 def test_auth_error(client):
-    respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
+    respx.post("https://api.acedata.cloud/openai/chat/completions").mock(
         return_value=httpx.Response(
             401, json={"error": {"code": "invalid_token", "message": "Bad token"}, "trace_id": "t-1"}
         )
@@ -282,7 +282,7 @@ def test_auth_error(client):
 
 @respx.mock
 def test_balance_error(client):
-    respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
+    respx.post("https://api.acedata.cloud/openai/chat/completions").mock(
         return_value=httpx.Response(
             403, json={"error": {"code": "used_up", "message": "Balance insufficient"}, "trace_id": "t-2"}
         )
@@ -293,7 +293,7 @@ def test_balance_error(client):
 
 @respx.mock
 def test_rate_limit_error(client):
-    respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
+    respx.post("https://api.acedata.cloud/openai/chat/completions").mock(
         return_value=httpx.Response(
             429, json={"error": {"code": "too_many_requests", "message": "Slow down"}, "trace_id": "t-3"}
         )
@@ -304,7 +304,7 @@ def test_rate_limit_error(client):
 
 @respx.mock
 def test_validation_error(client):
-    respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
+    respx.post("https://api.acedata.cloud/openai/chat/completions").mock(
         return_value=httpx.Response(
             400, json={"error": {"code": "bad_request", "message": "Invalid model"}, "trace_id": "t-4"}
         )
@@ -324,7 +324,7 @@ async def test_async_openai_completions(async_client):
         "choices": [{"index": 0, "message": {"role": "assistant", "content": "Async!"}, "finish_reason": "stop"}],
         "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
     }
-    respx.post("https://api.acedata.cloud/v1/chat/completions").mock(
+    respx.post("https://api.acedata.cloud/openai/chat/completions").mock(
         return_value=httpx.Response(200, json=mock_response)
     )
 


### PR DESCRIPTION
## What
Fix Python SDK tests to mock the same OpenAI compatibility path the SDK actually calls.

- update python/tests/test_sdk.py OpenAI chat/completions mocks
- replace https://api.acedata.cloud/v1/chat/completions
- with https://api.acedata.cloud/openai/chat/completions

## Why
Recent CI failures (before and after docs sync merge) all shared the same signature:

- SDK runtime calls /openai/chat/completions
- tests mocked /v1/chat/completions
- respx.models.AllMockedAssertionError

This PR aligns test mocks with current client behavior.

## Validation
- Local environment here is missing Python test deps (httpx), so full local pytest could not run in this shell.
- Change is narrowly scoped to endpoint strings in failing tests only; no runtime SDK code changed.
