### PR TITLE
feat: async param across Python/TS/Go SDKs

### DIFF
--- a/go/images.go
+++ b/go/images.go
@@ -17,6 +17,9 @@ type ImageGenerateRequest struct {
 	ImageURL string
 	// CallbackURL optionally receives the task completion webhook.
 	CallbackURL string
+	// Async, when true, returns a task_id without requiring a CallbackURL;
+	// poll the tasks endpoint for the result.
+	Async bool
 	// Extra fields merged into the request body.
 	Extra map[string]any
 }
@@ -34,6 +37,9 @@ func (r ImageGenerateRequest) toBody() map[string]any {
 	}
 	if r.CallbackURL != "" {
 		body["callback_url"] = r.CallbackURL
+	}
+	if r.Async {
+		body["async"] = true
 	}
 	for k, v := range r.Extra {
 		if _, exists := body[k]; !exists {

--- a/python/src/acedatacloud/resources/audio.py
+++ b/python/src/acedatacloud/resources/audio.py
@@ -60,6 +60,7 @@ class Audio:
         model: str | None = None,
         tags: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 5.0,
         max_wait: float = 600.0,
@@ -69,6 +70,8 @@ class Audio:
             body: dict[str, Any] = {"text": prompt, **kwargs}
             if callback_url is not None:
                 body["callback_url"] = callback_url
+            if async_ is not None:
+                body["async"] = async_
             result = self._transport.request(
                 "POST",
                 "/fish/tts",
@@ -83,6 +86,8 @@ class Audio:
                 body["tags"] = tags
             if callback_url is not None:
                 body["callback_url"] = callback_url
+            if async_ is not None:
+                body["async"] = async_
             result = self._transport.request("POST", f"/{provider}/audios", json=body)
         task_id = result.get("task_id")
 
@@ -146,6 +151,7 @@ class AsyncAudio:
         model: str | None = None,
         tags: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 5.0,
         max_wait: float = 600.0,
@@ -155,6 +161,8 @@ class AsyncAudio:
             body: dict[str, Any] = {"text": prompt, **kwargs}
             if callback_url is not None:
                 body["callback_url"] = callback_url
+            if async_ is not None:
+                body["async"] = async_
             result = await self._transport.request(
                 "POST",
                 "/fish/tts",
@@ -169,6 +177,8 @@ class AsyncAudio:
                 body["tags"] = tags
             if callback_url is not None:
                 body["callback_url"] = callback_url
+            if async_ is not None:
+                body["async"] = async_
             result = await self._transport.request("POST", f"/{provider}/audios", json=body)
         task_id = result.get("task_id")
 

--- a/python/src/acedatacloud/resources/images.py
+++ b/python/src/acedatacloud/resources/images.py
@@ -28,6 +28,7 @@ class Images:
         aspect_ratio: str | None = None,
         resolution: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 3.0,
         max_wait: float = 600.0,
@@ -50,6 +51,8 @@ class Images:
             body["resolution"] = resolution
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
 
         endpoint = "/midjourney/imagine" if provider == "midjourney" else f"/{provider}/images"
         result = self._transport.request("POST", endpoint, json=body)
@@ -83,6 +86,7 @@ class AsyncImages:
         aspect_ratio: str | None = None,
         resolution: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 3.0,
         max_wait: float = 600.0,
@@ -105,6 +109,8 @@ class AsyncImages:
             body["resolution"] = resolution
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
 
         endpoint = "/midjourney/imagine" if provider == "midjourney" else f"/{provider}/images"
         result = await self._transport.request("POST", endpoint, json=body)

--- a/python/src/acedatacloud/resources/kling.py
+++ b/python/src/acedatacloud/resources/kling.py
@@ -36,6 +36,7 @@ class Kling:
         cfg_scale: float | None = None,
         aspect_ratio: Literal["16:9", "9:16", "1:1"] | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         end_image_url: str | None = None,
         camera_control: str | None = None,
         element_list: list[Any] | None = None,
@@ -63,6 +64,8 @@ class Kling:
             body["aspect_ratio"] = aspect_ratio
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         if end_image_url is not None:
             body["end_image_url"] = end_image_url
         if camera_control is not None:
@@ -87,6 +90,7 @@ class Kling:
         keep_original_sound: Literal["yes", "no"] | None = None,
         prompt: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
@@ -102,6 +106,8 @@ class Kling:
             body["prompt"] = prompt
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/kling/motion", json=body)
 
 
@@ -124,6 +130,7 @@ class AsyncKling:
         cfg_scale: float | None = None,
         aspect_ratio: Literal["16:9", "9:16", "1:1"] | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         end_image_url: str | None = None,
         camera_control: str | None = None,
         element_list: list[Any] | None = None,
@@ -151,6 +158,8 @@ class AsyncKling:
             body["aspect_ratio"] = aspect_ratio
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         if end_image_url is not None:
             body["end_image_url"] = end_image_url
         if camera_control is not None:
@@ -175,6 +184,7 @@ class AsyncKling:
         keep_original_sound: Literal["yes", "no"] | None = None,
         prompt: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
@@ -190,4 +200,6 @@ class AsyncKling:
             body["prompt"] = prompt
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/kling/motion", json=body)

--- a/python/src/acedatacloud/resources/openai_compat.py
+++ b/python/src/acedatacloud/resources/openai_compat.py
@@ -131,6 +131,7 @@ class _Images:
         response_format: str | None = None,
         style: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"prompt": prompt, "model": model, **kwargs}
@@ -156,6 +157,8 @@ class _Images:
             body["style"] = style
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/openai/images/generations", json=body)
 
     def edit(
@@ -175,6 +178,7 @@ class _Images:
         size: str | None = None,
         response_format: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"image": image, "prompt": prompt, **kwargs}
@@ -202,6 +206,8 @@ class _Images:
             body["response_format"] = response_format
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/openai/images/edits", json=body)
 
 
@@ -225,6 +231,7 @@ class _AsyncImages:
         response_format: str | None = None,
         style: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"prompt": prompt, "model": model, **kwargs}
@@ -250,6 +257,8 @@ class _AsyncImages:
             body["style"] = style
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/openai/images/generations", json=body)
 
     async def edit(
@@ -269,6 +278,7 @@ class _AsyncImages:
         size: str | None = None,
         response_format: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"image": image, "prompt": prompt, **kwargs}
@@ -296,6 +306,8 @@ class _AsyncImages:
             body["response_format"] = response_format
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/openai/images/edits", json=body)
 
 

--- a/python/src/acedatacloud/resources/veo.py
+++ b/python/src/acedatacloud/resources/veo.py
@@ -25,6 +25,7 @@ class Veo:
         aspect_ratio: Literal["9:16", "1:1", "3:4", "4:3", "16:9"] | None = None,
         image_urls: list[str] | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"action": action, **kwargs}
@@ -44,6 +45,8 @@ class Veo:
             body["image_urls"] = image_urls
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/veo/videos", json=body)
 
     def upsample(
@@ -52,11 +55,14 @@ class Veo:
         video_id: str,
         action: Literal["1080p", "4k", "gif"],
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "action": action, **kwargs}
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/veo/upsample", json=body)
 
     def extend(
@@ -66,6 +72,7 @@ class Veo:
         model: str,
         prompt: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "model": model, **kwargs}
@@ -73,6 +80,8 @@ class Veo:
             body["prompt"] = prompt
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/veo/extend", json=body)
 
     def reshoot(
@@ -81,11 +90,14 @@ class Veo:
         video_id: str,
         motion_type: str,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "motion_type": motion_type, **kwargs}
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/veo/reshoot", json=body)
 
     def objects(
@@ -96,6 +108,7 @@ class Veo:
         prompt: str | None = None,
         image_mask: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "action": action, **kwargs}
@@ -105,6 +118,8 @@ class Veo:
             body["image_mask"] = image_mask
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/veo/objects", json=body)
 
 
@@ -126,6 +141,7 @@ class AsyncVeo:
         aspect_ratio: Literal["9:16", "1:1", "3:4", "4:3", "16:9"] | None = None,
         image_urls: list[str] | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"action": action, **kwargs}
@@ -145,6 +161,8 @@ class AsyncVeo:
             body["image_urls"] = image_urls
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/veo/videos", json=body)
 
     async def upsample(
@@ -153,11 +171,14 @@ class AsyncVeo:
         video_id: str,
         action: Literal["1080p", "4k", "gif"],
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "action": action, **kwargs}
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/veo/upsample", json=body)
 
     async def extend(
@@ -167,6 +188,7 @@ class AsyncVeo:
         model: str,
         prompt: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "model": model, **kwargs}
@@ -174,6 +196,8 @@ class AsyncVeo:
             body["prompt"] = prompt
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/veo/extend", json=body)
 
     async def reshoot(
@@ -182,11 +206,14 @@ class AsyncVeo:
         video_id: str,
         motion_type: str,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "motion_type": motion_type, **kwargs}
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/veo/reshoot", json=body)
 
     async def objects(
@@ -197,6 +224,7 @@ class AsyncVeo:
         prompt: str | None = None,
         image_mask: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"video_id": video_id, "action": action, **kwargs}
@@ -206,4 +234,6 @@ class AsyncVeo:
             body["image_mask"] = image_mask
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/veo/objects", json=body)

--- a/python/src/acedatacloud/resources/video.py
+++ b/python/src/acedatacloud/resources/video.py
@@ -23,6 +23,7 @@ class Video:
         model: str | None = None,
         image_url: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 5.0,
         max_wait: float = 600.0,
@@ -35,6 +36,8 @@ class Video:
             body["image_url"] = image_url
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
 
         result = self._transport.request("POST", f"/{provider}/videos", json=body)
         task_id = result.get("task_id")
@@ -62,6 +65,7 @@ class AsyncVideo:
         model: str | None = None,
         image_url: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 5.0,
         max_wait: float = 600.0,
@@ -74,6 +78,8 @@ class AsyncVideo:
             body["image_url"] = image_url
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
 
         result = await self._transport.request("POST", f"/{provider}/videos", json=body)
         task_id = result.get("task_id")

--- a/python/src/acedatacloud/resources/webextrator.py
+++ b/python/src/acedatacloud/resources/webextrator.py
@@ -25,6 +25,7 @@ class WebExtrator:
         headers: dict[str, str] | None = None,
         user_agent: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"url": url, **kwargs}
@@ -48,6 +49,8 @@ class WebExtrator:
             body["user_agent"] = user_agent
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/webextrator/extract", json=body)
 
     def render(
@@ -62,6 +65,7 @@ class WebExtrator:
         headers: dict[str, str] | None = None,
         user_agent: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"url": url, **kwargs}
@@ -81,6 +85,8 @@ class WebExtrator:
             body["user_agent"] = user_agent
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return self._transport.request("POST", "/webextrator/render", json=body)
 
 
@@ -104,6 +110,7 @@ class AsyncWebExtrator:
         headers: dict[str, str] | None = None,
         user_agent: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"url": url, **kwargs}
@@ -127,6 +134,8 @@ class AsyncWebExtrator:
             body["user_agent"] = user_agent
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/webextrator/extract", json=body)
 
     async def render(
@@ -141,6 +150,7 @@ class AsyncWebExtrator:
         headers: dict[str, str] | None = None,
         user_agent: str | None = None,
         callback_url: str | None = None,
+        async_: bool | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"url": url, **kwargs}
@@ -160,4 +170,6 @@ class AsyncWebExtrator:
             body["user_agent"] = user_agent
         if callback_url is not None:
             body["callback_url"] = callback_url
+        if async_ is not None:
+            body["async"] = async_
         return await self._transport.request("POST", "/webextrator/render", json=body)

--- a/typescript/src/resources/audio.ts
+++ b/typescript/src/resources/audio.ts
@@ -43,6 +43,7 @@ export class Audio {
     model?: string;
     tags?: string;
     callbackUrl?: string;
+    async?: boolean;
     wait?: boolean;
     pollInterval?: number;
     maxWait?: number;

--- a/typescript/src/resources/images.ts
+++ b/typescript/src/resources/images.ts
@@ -19,6 +19,7 @@ export class Images {
     aspectRatio?: string;
     resolution?: string;
     callbackUrl?: string;
+    async?: boolean;
     wait?: boolean;
     pollInterval?: number;
     maxWait?: number;

--- a/typescript/src/resources/kling.ts
+++ b/typescript/src/resources/kling.ts
@@ -28,6 +28,7 @@ export class Kling {
     cfgScale?: number;
     aspectRatio?: '16:9' | '9:16' | '1:1';
     callbackUrl?: string;
+    async?: boolean;
     endImageUrl?: string;
     cameraControl?: string;
     elementList?: unknown[];
@@ -82,6 +83,7 @@ export class Kling {
     keepOriginalSound?: 'yes' | 'no';
     prompt?: string;
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { mode, imageUrl, videoUrl, characterOrientation, keepOriginalSound, prompt, callbackUrl, ...rest } = opts;

--- a/typescript/src/resources/openai.ts
+++ b/typescript/src/resources/openai.ts
@@ -102,6 +102,7 @@ class Images {
     responseFormat?: string;
     style?: string;
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { prompt, model, outputCompression, outputFormat, partialImages, responseFormat, callbackUrl, ...rest } = opts;
@@ -129,6 +130,7 @@ class Images {
     size?: string;
     responseFormat?: string;
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { image, prompt, inputFidelity, mask, outputFormat, outputCompression, partialImages, responseFormat, callbackUrl, ...rest } = opts;

--- a/typescript/src/resources/veo.ts
+++ b/typescript/src/resources/veo.ts
@@ -17,6 +17,7 @@ export class Veo {
     aspectRatio?: '9:16' | '1:1' | '3:4' | '4:3' | '16:9';
     imageUrls?: string[];
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { action, prompt, model, resolution, videoId, translation, aspectRatio, imageUrls, callbackUrl, ...rest } = opts;
@@ -36,6 +37,7 @@ export class Veo {
     videoId: string;
     action: '1080p' | '4k' | 'gif';
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { videoId, action, callbackUrl, ...rest } = opts;
@@ -49,6 +51,7 @@ export class Veo {
     model: 'veo31-fast' | 'veo31' | (string & {});
     prompt?: string;
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { videoId, model, prompt, callbackUrl, ...rest } = opts;
@@ -62,6 +65,7 @@ export class Veo {
     videoId: string;
     motionType: 'STATIONARY' | 'STATIONARY_UP' | 'STATIONARY_DOWN' | 'STATIONARY_LEFT' | 'STATIONARY_RIGHT' | 'STATIONARY_DOLLY_IN_ZOOM_OUT' | 'STATIONARY_DOLLY_OUT_ZOOM_IN' | 'UP' | 'DOWN' | 'LEFT_TO_RIGHT' | 'RIGHT_TO_LEFT' | 'FORWARD' | 'BACKWARD' | 'DOLLY_IN_ZOOM_OUT' | 'DOLLY_OUT_ZOOM_IN' | (string & {});
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { videoId, motionType, callbackUrl, ...rest } = opts;
@@ -76,6 +80,7 @@ export class Veo {
     prompt?: string;
     imageMask?: string;
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { videoId, action, prompt, imageMask, callbackUrl, ...rest } = opts;

--- a/typescript/src/resources/video.ts
+++ b/typescript/src/resources/video.ts
@@ -14,6 +14,7 @@ export class Video {
     model?: string;
     imageUrl?: string;
     callbackUrl?: string;
+    async?: boolean;
     wait?: boolean;
     pollInterval?: number;
     maxWait?: number;

--- a/typescript/src/resources/webextrator.ts
+++ b/typescript/src/resources/webextrator.ts
@@ -17,6 +17,7 @@ export class WebExtrator {
     headers?: Record<string, string>;
     userAgent?: string;
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { url, expectedType, enableLlm, waitUntil, timeout, delay, waitForSelector, blockResources, headers, userAgent, callbackUrl, ...rest } = opts;
@@ -44,6 +45,7 @@ export class WebExtrator {
     headers?: Record<string, string>;
     userAgent?: string;
     callbackUrl?: string;
+    async?: boolean;
     [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
     const { url, waitUntil, timeout, delay, waitForSelector, blockResources, headers, userAgent, callbackUrl, ...rest } = opts;


### PR DESCRIPTION
Adds an `async` request param to every async-capable SDK method, mirroring the new API-level `async: true` flag (returns task_id immediately without a callback_url; poll the tasks endpoint).

- **Python**: `async_: bool | None = None` (`async` is a reserved word) → `body["async"]`
- **TypeScript**: `async?: boolean` on each opts type (passed through to body via `...rest`)
- **Go**: `Async bool` on `ImageGenerateRequest` → `body["async"]`

Added wherever `callback_url` already existed (7 py + 7 ts + 1 go files). Verified: py_compile, ruff, tsc --noEmit, go build/vet all pass.

Part of the cross-stack async:true rollout (workers PS#1019, openapi PB#662 already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)