### PR TITLE
chore: remove Midjourney SDK provider support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ When the Docs repo changes, compare the OpenAPI specs against the SDK code and u
 
 4. **API paths** in resource files:
    - Verify endpoint paths match the OpenAPI `paths` section
-   - Special cases (e.g., midjourney uses `/midjourney/imagine` not `/midjourney/images`)
+   - Account for provider-specific path shapes when OpenAPI specs differ
 
 ### Python (`python/src/acedatacloud/`)
 

--- a/.plans/SDK-RFC.md
+++ b/.plans/SDK-RFC.md
@@ -122,7 +122,6 @@ Examples:
 - Nano Banana
 - Seedream
 - Flux
-- Midjourney image flows in later phases
 
 ### `audio`
 

--- a/go/images.go
+++ b/go/images.go
@@ -6,8 +6,7 @@ import "context"
 type ImageGenerateRequest struct {
 	// Prompt is the required text prompt.
 	Prompt string
-	// Provider selects the backend. Common values: "nano-banana",
-	// "midjourney", "flux", "seedream".
+	// Provider selects the backend. Common values: "nano-banana", "flux", "seedream".
 	Provider string
 	// Model is optional — provider-specific model identifier.
 	Model string
@@ -65,9 +64,6 @@ func (i *ImagesResource) Generate(ctx context.Context, req ImageGenerateRequest)
 		provider = "nano-banana"
 	}
 	endpoint := "/" + provider + "/images"
-	if provider == "midjourney" {
-		endpoint = "/midjourney/imagine"
-	}
 	body := req.toBody()
 	result, err := i.t.do(ctx, requestOpts{Method: "POST", Path: endpoint, Body: body})
 	if err != nil {

--- a/go/tasks_resource.go
+++ b/go/tasks_resource.go
@@ -13,7 +13,6 @@ var serviceTaskEndpoints = map[string]string{
 	"seedream":    "/seedream/tasks",
 	"seedance":    "/seedance/tasks",
 	"sora":        "/sora/tasks",
-	"midjourney":  "/midjourney/tasks",
 	"luma":        "/luma/tasks",
 	"veo":         "/veo/tasks",
 	"flux":        "/flux/tasks",

--- a/python/README.md
+++ b/python/README.md
@@ -52,7 +52,7 @@ asyncio.run(main())
 |----------|-------------|
 | `client.openai` | OpenAI-compatible chat completions and responses |
 | `client.chat` | Native chat messages |
-| `client.images` | Image generation (Midjourney, Flux, etc.) |
+| `client.images` | Image generation (Flux, Seedream, Nano Banana, etc.) |
 | `client.audio` | Music generation (Suno) |
 | `client.video` | Video generation (Luma, Sora, Veo, etc.) |
 | `client.search` | Web search (Google SERP) |
@@ -69,7 +69,7 @@ result = task.wait()  # polls until complete
 print(result["image_url"])
 
 # Use a specific provider
-mj_task = client.images.generate(prompt="A sunset over mountains", provider="midjourney")
+flux_task = client.images.generate(prompt="A sunset over mountains", provider="flux")
 ```
 
 ## Multi-Provider Support
@@ -89,8 +89,8 @@ Available providers:
 
 | Resource | Providers |
 |----------|-----------|
-| `client.images` | `nano-banana` (default), `midjourney`, `flux`, `seedream` |
-| `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse`, `midjourney` |
+| `client.images` | `nano-banana` (default), `flux`, `seedream` |
+| `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse` |
 | `client.audio` | `suno` (default), `producer`, `fish` |
 
 ## Error Handling

--- a/python/src/acedatacloud/resources/images.py
+++ b/python/src/acedatacloud/resources/images.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
 
-ImageProvider = Literal["nano-banana", "midjourney", "flux", "seedream"]
+ImageProvider = Literal["nano-banana", "flux", "seedream"]
 
 
 class Images:
@@ -54,7 +54,7 @@ class Images:
         if async_ is not None:
             body["async"] = async_
 
-        endpoint = "/midjourney/imagine" if provider == "midjourney" else f"/{provider}/images"
+        endpoint = f"/{provider}/images"
         result = self._transport.request("POST", endpoint, json=body)
         task_id = result.get("task_id")
 
@@ -112,7 +112,7 @@ class AsyncImages:
         if async_ is not None:
             body["async"] = async_
 
-        endpoint = "/midjourney/imagine" if provider == "midjourney" else f"/{provider}/images"
+        endpoint = f"/{provider}/images"
         result = await self._transport.request("POST", endpoint, json=body)
         task_id = result.get("task_id")
 

--- a/python/src/acedatacloud/resources/tasks.py
+++ b/python/src/acedatacloud/resources/tasks.py
@@ -14,7 +14,6 @@ _SERVICE_TASK_ENDPOINTS = {
     "seedream": "/seedream/tasks",
     "seedance": "/seedance/tasks",
     "sora": "/sora/tasks",
-    "midjourney": "/midjourney/tasks",
     "luma": "/luma/tasks",
     "veo": "/veo/tasks",
     "flux": "/flux/tasks",

--- a/python/src/acedatacloud/resources/video.py
+++ b/python/src/acedatacloud/resources/video.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
 
-VideoProvider = Literal["sora", "luma", "veo", "kling", "hailuo", "seedance", "wan", "pika", "pixverse", "midjourney"]
+VideoProvider = Literal["sora", "luma", "veo", "kling", "hailuo", "seedance", "wan", "pika", "pixverse"]
 
 
 class Video:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -45,7 +45,7 @@ for await (const chunk of stream) {
 |----------|-------------|
 | `client.openai` | OpenAI-compatible chat completions and responses |
 | `client.chat` | Native chat messages |
-| `client.images` | Image generation (Midjourney, Flux, etc.) |
+| `client.images` | Image generation (Flux, Seedream, Nano Banana, etc.) |
 | `client.audio` | Music generation (Suno) |
 | `client.video` | Video generation (Luma, Sora, Veo, etc.) |
 | `client.search` | Web search (Google SERP) |
@@ -62,9 +62,9 @@ const result = await task.wait();
 console.log(result.image_url);
 
 // Use a specific provider
-const mjTask = await client.images.generate({
+const fluxTask = await client.images.generate({
   prompt: 'A sunset over mountains',
-  provider: 'midjourney',
+  provider: 'flux',
 });
 ```
 
@@ -85,8 +85,8 @@ Available providers:
 
 | Resource | Providers |
 |----------|-----------|
-| `client.images` | `nano-banana` (default), `midjourney`, `flux`, `seedream` |
-| `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse`, `midjourney` |
+| `client.images` | `nano-banana` (default), `flux`, `seedream` |
+| `client.video` | `sora` (default), `luma`, `veo`, `kling`, `hailuo`, `seedance`, `wan`, `pika`, `pixverse` |
 | `client.audio` | `suno` (default), `producer`, `fish` |
 
 ## Error Handling

--- a/typescript/src/resources/images.ts
+++ b/typescript/src/resources/images.ts
@@ -3,7 +3,7 @@
 import { Transport } from '../runtime/transport';
 import { TaskHandle } from '../runtime/tasks';
 
-export type ImageProvider = 'nano-banana' | 'midjourney' | 'flux' | 'seedream' | (string & {});
+export type ImageProvider = 'nano-banana' | 'flux' | 'seedream' | (string & {});
 
 export class Images {
   constructor(private transport: Transport) {}
@@ -36,7 +36,7 @@ export class Images {
     if (resolution !== undefined) body.resolution = resolution;
     if (callbackUrl !== undefined) body.callback_url = callbackUrl;
 
-    const endpoint = provider === 'midjourney' ? '/midjourney/imagine' : `/${provider}/images`;
+    const endpoint = `/${provider}/images`;
     const result = await this.transport.request('POST', endpoint, { json: body });
     const taskId = result.task_id as string | undefined;
 

--- a/typescript/src/resources/tasks.ts
+++ b/typescript/src/resources/tasks.ts
@@ -11,7 +11,6 @@ const SERVICE_TASK_ENDPOINTS: Record<string, string> = {
   seedream: '/seedream/tasks',
   seedance: '/seedance/tasks',
   sora: '/sora/tasks',
-  midjourney: '/midjourney/tasks',
   luma: '/luma/tasks',
   veo: '/veo/tasks',
   flux: '/flux/tasks',

--- a/typescript/src/resources/video.ts
+++ b/typescript/src/resources/video.ts
@@ -3,7 +3,7 @@
 import { Transport } from '../runtime/transport';
 import { TaskHandle } from '../runtime/tasks';
 
-export type VideoProvider = 'sora' | 'luma' | 'veo' | 'kling' | 'hailuo' | 'seedance' | 'wan' | 'pika' | 'pixverse' | 'midjourney' | (string & {});
+export type VideoProvider = 'sora' | 'luma' | 'veo' | 'kling' | 'hailuo' | 'seedance' | 'wan' | 'pika' | 'pixverse' | (string & {});
 
 export class Video {
   constructor(private transport: Transport) {}


### PR DESCRIPTION
## Summary
- Remove Midjourney provider literals, special `/midjourney/*` endpoint handling, and task endpoint mappings from Python, TypeScript, and Go SDKs.
- Remove Midjourney SDK examples and provider lists from Python/TypeScript READMEs and internal SDK guidance docs.

## Validation
- `rg --hidden -n 'Midjourney|midjourney|/midjourney|mcp-midjourney|midjourney-pro-cli' .worktrees/SDK-midjourney-takedown -g '!*.lock' -g '!.git' -g '!.git/**'` returned no matches.
- `python3 -m compileall -q python/src`
- `go test ./...` in `go/`
- `npm run lint` in `typescript/` (`tsc --noEmit`)

## 🤖 对抗评审
- Reviewer: read-only subagent review across Clis/MCPs/APIs/Skills/SDK takedown diffs.
- Verdict: `VERDICT: CLEAN`
- Findings: no blocking issues; SDK retains generic provider extensibility but no advertised or special-cased Midjourney support.
