### PR TITLE
feat: add face + shorturl resources, bring Go SDK to parity

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -74,6 +74,19 @@ handle, _, err := client.Images().Generate(ctx, acedatacloud.ImageGenerateReques
 res, err := handle.Wait(ctx, 3*time.Second, 5*time.Minute)
 ```
 
+## More resources
+
+```go
+// Video / audio task-based generation (sora|luma|veo|kling|hailuo|seedance|wan|pixverse, suno|producer|fish)
+vh, _, _ := client.Video().Generate(ctx, acedatacloud.VideoGenerateRequest{Prompt: "a cat", Provider: "kling"})
+ah, _, _ := client.Audio().Generate(ctx, acedatacloud.AudioGenerateRequest{Prompt: "lofi beat", Provider: "suno"})
+
+// Web search, face transforms, short URLs
+client.Search().Google(ctx, acedatacloud.SearchRequest{Query: "AceDataCloud"})
+client.Face().Swap(ctx, "https://a.png", "https://b.png", nil)
+client.ShortURL().Create(ctx, "https://acedata.cloud", "", nil)
+```
+
 ## Paying per request with x402
 
 ```go

--- a/go/audio.go
+++ b/go/audio.go
@@ -1,0 +1,77 @@
+package acedatacloud
+
+import "context"
+
+// AudioGenerateRequest is the input to audio.generate.
+type AudioGenerateRequest struct {
+	// Prompt is the required text prompt (or text-to-speech text for fish).
+	Prompt string
+	// Provider selects the backend: "suno", "producer", "fish".
+	Provider string
+	// Model is optional — provider-specific model identifier.
+	Model string
+	// Tags is optional style tags (suno/producer).
+	Tags string
+	// CallbackURL optionally receives the task completion webhook.
+	CallbackURL string
+	// Async, when true, returns a task_id without requiring a CallbackURL.
+	Async bool
+	// Extra fields merged into the request body.
+	Extra map[string]any
+}
+
+// AudioResource groups audio/music generation endpoints.
+type AudioResource struct{ t *transport }
+
+// Generate enqueues an audio task. It returns a TaskHandle for polling
+// when the server responds asynchronously, or the direct result map when
+// the server produced the audio synchronously.
+func (a *AudioResource) Generate(ctx context.Context, req AudioGenerateRequest) (*TaskHandle, map[string]any, error) {
+	provider := req.Provider
+	if provider == "" {
+		provider = "suno"
+	}
+	var (
+		body     map[string]any
+		endpoint string
+		headers  map[string]string
+	)
+	if provider == "fish" {
+		body = map[string]any{"text": req.Prompt}
+		endpoint = "/fish/tts"
+		// Fish selects the voice model via a header, not the body.
+		if req.Model != "" {
+			headers = map[string]string{"model": req.Model}
+		}
+	} else {
+		body = map[string]any{"prompt": req.Prompt}
+		if req.Tags != "" {
+			body["tags"] = req.Tags
+		}
+		if req.Model != "" {
+			body["model"] = req.Model
+		}
+		endpoint = "/" + provider + "/audios"
+	}
+	if req.CallbackURL != "" {
+		body["callback_url"] = req.CallbackURL
+	}
+	if req.Async {
+		body["async"] = true
+	}
+	for k, v := range req.Extra {
+		if _, exists := body[k]; !exists {
+			body[k] = v
+		}
+	}
+	result, err := a.t.do(ctx, requestOpts{Method: "POST", Path: endpoint, Body: body, ExtraHeaders: headers})
+	if err != nil {
+		return nil, nil, err
+	}
+	taskID, _ := result["task_id"].(string)
+	if taskID == "" {
+		return nil, result, nil
+	}
+	handle := &TaskHandle{ID: taskID, pollEndpoint: endpointFor(provider), transport: a.t}
+	return handle, result, nil
+}

--- a/go/client.go
+++ b/go/client.go
@@ -3,15 +3,20 @@ package acedatacloud
 // Client is the top-level AceDataCloud SDK client.
 //
 // It exposes domain-specific resource groups via accessor methods,
-// mirroring the Python ``AceDataCloud`` class and the TypeScript
-// ``AceDataCloud`` class.
+// mirroring the Python “AceDataCloud“ class and the TypeScript
+// “AceDataCloud“ class.
 type Client struct {
 	transport *transport
 
-	openai *OpenAIResource
-	chat   *ChatResource
-	images *ImagesResource
-	tasks  *TasksResource
+	openai   *OpenAIResource
+	chat     *ChatResource
+	images   *ImagesResource
+	tasks    *TasksResource
+	video    *VideoResource
+	audio    *AudioResource
+	search   *SearchResource
+	face     *FaceResource
+	shorturl *ShortURLResource
 }
 
 // NewClient constructs a Client. At least one of WithAPIToken /
@@ -30,14 +35,19 @@ func NewClient(opts ...Option) (*Client, error) {
 	c.chat = &ChatResource{t: tr}
 	c.images = &ImagesResource{t: tr}
 	c.tasks = &TasksResource{t: tr}
+	c.video = &VideoResource{t: tr}
+	c.audio = &AudioResource{t: tr}
+	c.search = &SearchResource{t: tr}
+	c.face = &FaceResource{t: tr}
+	c.shorturl = &ShortURLResource{t: tr}
 	return c, nil
 }
 
-// OpenAI returns the OpenAI-compatible resource (``/v1/chat/completions``,
-// ``/openai/responses``).
+// OpenAI returns the OpenAI-compatible resource (“/v1/chat/completions“,
+// “/openai/responses“).
 func (c *Client) OpenAI() *OpenAIResource { return c.openai }
 
-// Chat returns the native chat resource (``/v1/messages`` — Anthropic
+// Chat returns the native chat resource (“/v1/messages“ — Anthropic
 // Messages API shape).
 func (c *Client) Chat() *ChatResource { return c.chat }
 
@@ -46,3 +56,18 @@ func (c *Client) Images() *ImagesResource { return c.images }
 
 // Tasks returns the cross-service task retrieval resource.
 func (c *Client) Tasks() *TasksResource { return c.tasks }
+
+// Video returns the video-generation resource.
+func (c *Client) Video() *VideoResource { return c.video }
+
+// Audio returns the audio/music generation resource.
+func (c *Client) Audio() *AudioResource { return c.audio }
+
+// Search returns the web search resource.
+func (c *Client) Search() *SearchResource { return c.search }
+
+// Face returns the face transformation resource.
+func (c *Client) Face() *FaceResource { return c.face }
+
+// ShortURL returns the short URL resource.
+func (c *Client) ShortURL() *ShortURLResource { return c.shorturl }

--- a/go/face.go
+++ b/go/face.go
@@ -1,0 +1,62 @@
+package acedatacloud
+
+import "context"
+
+// FaceResource groups face transformation endpoints (“/face/*“).
+type FaceResource struct{ t *transport }
+
+func (f *FaceResource) call(ctx context.Context, action string, body map[string]any) (map[string]any, error) {
+	return f.t.do(ctx, requestOpts{Method: "POST", Path: "/face/" + action, Body: body})
+}
+
+// Analyze detects face keypoints for the image at imageURL. Extra is
+// merged into the request body for forward-compatible fields.
+func (f *FaceResource) Analyze(ctx context.Context, imageURL string, extra map[string]any) (map[string]any, error) {
+	return f.call(ctx, "analyze", withImage(imageURL, extra))
+}
+
+// Beautify beautifies a portrait.
+func (f *FaceResource) Beautify(ctx context.Context, imageURL string, extra map[string]any) (map[string]any, error) {
+	return f.call(ctx, "beautify", withImage(imageURL, extra))
+}
+
+// ChangeAge ages or de-ages a face.
+func (f *FaceResource) ChangeAge(ctx context.Context, imageURL string, extra map[string]any) (map[string]any, error) {
+	return f.call(ctx, "change-age", withImage(imageURL, extra))
+}
+
+// ChangeGender swaps the perceived gender of a face.
+func (f *FaceResource) ChangeGender(ctx context.Context, imageURL string, extra map[string]any) (map[string]any, error) {
+	return f.call(ctx, "change-gender", withImage(imageURL, extra))
+}
+
+// DetectLive runs liveness detection.
+func (f *FaceResource) DetectLive(ctx context.Context, imageURL string, extra map[string]any) (map[string]any, error) {
+	return f.call(ctx, "detect-live", withImage(imageURL, extra))
+}
+
+// Swap replaces the face in target with the face from source.
+func (f *FaceResource) Swap(ctx context.Context, sourceImageURL, targetImageURL string, extra map[string]any) (map[string]any, error) {
+	body := map[string]any{"source_image_url": sourceImageURL, "target_image_url": targetImageURL}
+	for k, v := range extra {
+		if _, ok := body[k]; !ok {
+			body[k] = v
+		}
+	}
+	return f.call(ctx, "swap", body)
+}
+
+// Cartoon creates a cartoon avatar from a portrait.
+func (f *FaceResource) Cartoon(ctx context.Context, imageURL string, extra map[string]any) (map[string]any, error) {
+	return f.call(ctx, "cartoon", withImage(imageURL, extra))
+}
+
+func withImage(imageURL string, extra map[string]any) map[string]any {
+	body := map[string]any{"image_url": imageURL}
+	for k, v := range extra {
+		if _, ok := body[k]; !ok {
+			body[k] = v
+		}
+	}
+	return body
+}

--- a/go/search.go
+++ b/go/search.go
@@ -1,0 +1,45 @@
+package acedatacloud
+
+import "context"
+
+// SearchRequest is the input to search.Google.
+type SearchRequest struct {
+	// Query is the required search query.
+	Query string
+	// Type selects the SERP type: "search" (default), "images", "news", etc.
+	Type string
+	// Country and Language are optional localization hints.
+	Country  string
+	Language string
+	// Page is the optional 1-based result page.
+	Page int
+	// Extra fields merged into the request body.
+	Extra map[string]any
+}
+
+// SearchResource groups web search endpoints (“/serp/google“).
+type SearchResource struct{ t *transport }
+
+// Google performs a blocking Google search.
+func (s *SearchResource) Google(ctx context.Context, req SearchRequest) (map[string]any, error) {
+	typ := req.Type
+	if typ == "" {
+		typ = "search"
+	}
+	body := map[string]any{"query": req.Query, "type": typ}
+	if req.Country != "" {
+		body["country"] = req.Country
+	}
+	if req.Language != "" {
+		body["language"] = req.Language
+	}
+	if req.Page > 0 {
+		body["page"] = req.Page
+	}
+	for k, v := range req.Extra {
+		if _, exists := body[k]; !exists {
+			body[k] = v
+		}
+	}
+	return s.t.do(ctx, requestOpts{Method: "POST", Path: "/serp/google", Body: body})
+}

--- a/go/shorturl.go
+++ b/go/shorturl.go
@@ -1,0 +1,21 @@
+package acedatacloud
+
+import "context"
+
+// ShortURLResource exposes the short URL endpoint (“/shorturl“).
+type ShortURLResource struct{ t *transport }
+
+// Create shortens a URL. slug is optional (pass "" for an auto slug);
+// extra is merged into the request body for forward-compatible fields.
+func (s *ShortURLResource) Create(ctx context.Context, url, slug string, extra map[string]any) (map[string]any, error) {
+	body := map[string]any{"url": url}
+	if slug != "" {
+		body["slug"] = slug
+	}
+	for k, v := range extra {
+		if _, ok := body[k]; !ok {
+			body[k] = v
+		}
+	}
+	return s.t.do(ctx, requestOpts{Method: "POST", Path: "/shorturl", Body: body})
+}

--- a/go/video.go
+++ b/go/video.go
@@ -1,0 +1,67 @@
+package acedatacloud
+
+import "context"
+
+// VideoGenerateRequest is the input to videos.generate.
+type VideoGenerateRequest struct {
+	// Prompt is the required text prompt.
+	Prompt string
+	// Provider selects the backend: "sora", "luma", "veo", "kling",
+	// "hailuo", "seedance", "wan", "pika", "pixverse".
+	Provider string
+	// Model is optional — provider-specific model identifier.
+	Model string
+	// ImageURL is optional reference image for image-to-video.
+	ImageURL string
+	// CallbackURL optionally receives the task completion webhook.
+	CallbackURL string
+	// Async, when true, returns a task_id without requiring a CallbackURL.
+	Async bool
+	// Extra fields merged into the request body.
+	Extra map[string]any
+}
+
+func (r VideoGenerateRequest) toBody() map[string]any {
+	body := map[string]any{"prompt": r.Prompt}
+	if r.Model != "" {
+		body["model"] = r.Model
+	}
+	if r.ImageURL != "" {
+		body["image_url"] = r.ImageURL
+	}
+	if r.CallbackURL != "" {
+		body["callback_url"] = r.CallbackURL
+	}
+	if r.Async {
+		body["async"] = true
+	}
+	for k, v := range r.Extra {
+		if _, exists := body[k]; !exists {
+			body[k] = v
+		}
+	}
+	return body
+}
+
+// VideoResource groups video-generation endpoints.
+type VideoResource struct{ t *transport }
+
+// Generate enqueues a video-generation task. It returns a TaskHandle for
+// polling when the server responds asynchronously, or the direct result
+// map when the server produced the video synchronously.
+func (v *VideoResource) Generate(ctx context.Context, req VideoGenerateRequest) (*TaskHandle, map[string]any, error) {
+	provider := req.Provider
+	if provider == "" {
+		provider = "sora"
+	}
+	result, err := v.t.do(ctx, requestOpts{Method: "POST", Path: "/" + provider + "/videos", Body: req.toBody()})
+	if err != nil {
+		return nil, nil, err
+	}
+	taskID, _ := result["task_id"].(string)
+	if taskID == "" {
+		return nil, result, nil
+	}
+	handle := &TaskHandle{ID: taskID, pollEndpoint: endpointFor(provider), transport: v.t}
+	return handle, result, nil
+}

--- a/python/README.md
+++ b/python/README.md
@@ -56,6 +56,8 @@ asyncio.run(main())
 | `client.audio` | Music generation (Suno) |
 | `client.video` | Video generation (Luma, Sora, Veo, etc.) |
 | `client.search` | Web search (Google SERP) |
+| `client.face` | Face analysis & transformation (swap, beautify, age, cartoon) |
+| `client.shorturl` | Short URL creation |
 | `client.tasks` | Cross-service async task polling |
 | `client.files` | File uploads |
 | `client.platform` | Applications, credentials, models management |

--- a/python/src/acedatacloud/_client.py
+++ b/python/src/acedatacloud/_client.py
@@ -12,6 +12,7 @@ from acedatacloud._runtime.transport import AsyncTransport, SyncTransport
 from acedatacloud.resources.aichat import AiChat, AsyncAiChat
 from acedatacloud.resources.audio import AsyncAudio, Audio
 from acedatacloud.resources.chat import AsyncChat, Chat
+from acedatacloud.resources.face import AsyncFace, Face
 from acedatacloud.resources.files import AsyncFiles, Files
 from acedatacloud.resources.glm import AsyncGlm, Glm
 from acedatacloud.resources.images import AsyncImages, Images
@@ -19,6 +20,7 @@ from acedatacloud.resources.kling import AsyncKling, Kling
 from acedatacloud.resources.openai_compat import AsyncOpenAI, OpenAI
 from acedatacloud.resources.platform import AsyncPlatform, Platform
 from acedatacloud.resources.search import AsyncSearch, Search
+from acedatacloud.resources.shorturl import AsyncShortUrl, ShortUrl
 from acedatacloud.resources.tasks import AsyncTasks, Tasks
 from acedatacloud.resources.veo import AsyncVeo, Veo
 from acedatacloud.resources.video import AsyncVideo, Video
@@ -65,6 +67,8 @@ class AceDataCloud:
         self.veo = Veo(self._transport)
         self.kling = Kling(self._transport)
         self.webextrator = WebExtrator(self._transport)
+        self.face = Face(self._transport)
+        self.shorturl = ShortUrl(self._transport)
 
     def close(self) -> None:
         self._transport.close()
@@ -113,6 +117,8 @@ class AsyncAceDataCloud:
         self.veo = AsyncVeo(self._transport)
         self.kling = AsyncKling(self._transport)
         self.webextrator = AsyncWebExtrator(self._transport)
+        self.face = AsyncFace(self._transport)
+        self.shorturl = AsyncShortUrl(self._transport)
 
     async def close(self) -> None:
         await self._transport.close()

--- a/python/src/acedatacloud/resources/face.py
+++ b/python/src/acedatacloud/resources/face.py
@@ -1,0 +1,71 @@
+"""Face transformation resources (``/face/*``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class Face:
+    """Synchronous face transformation client."""
+
+    def __init__(self, transport: Any) -> None:
+        self._transport = transport
+
+    def _call(self, action: str, body: dict[str, Any]) -> dict[str, Any]:
+        return self._transport.request("POST", f"/face/{action}", json=body)
+
+    def analyze(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return self._call("analyze", {"image_url": image_url, **kwargs})
+
+    def beautify(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return self._call("beautify", {"image_url": image_url, **kwargs})
+
+    def change_age(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return self._call("change-age", {"image_url": image_url, **kwargs})
+
+    def change_gender(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return self._call("change-gender", {"image_url": image_url, **kwargs})
+
+    def detect_live(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return self._call("detect-live", {"image_url": image_url, **kwargs})
+
+    def swap(self, *, source_image_url: str, target_image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return self._call(
+            "swap", {"source_image_url": source_image_url, "target_image_url": target_image_url, **kwargs}
+        )
+
+    def cartoon(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return self._call("cartoon", {"image_url": image_url, **kwargs})
+
+
+class AsyncFace:
+    """Async face transformation client."""
+
+    def __init__(self, transport: Any) -> None:
+        self._transport = transport
+
+    async def _call(self, action: str, body: dict[str, Any]) -> dict[str, Any]:
+        return await self._transport.request("POST", f"/face/{action}", json=body)
+
+    async def analyze(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call("analyze", {"image_url": image_url, **kwargs})
+
+    async def beautify(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call("beautify", {"image_url": image_url, **kwargs})
+
+    async def change_age(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call("change-age", {"image_url": image_url, **kwargs})
+
+    async def change_gender(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call("change-gender", {"image_url": image_url, **kwargs})
+
+    async def detect_live(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call("detect-live", {"image_url": image_url, **kwargs})
+
+    async def swap(self, *, source_image_url: str, target_image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(
+            "swap", {"source_image_url": source_image_url, "target_image_url": target_image_url, **kwargs}
+        )
+
+    async def cartoon(self, *, image_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call("cartoon", {"image_url": image_url, **kwargs})

--- a/python/src/acedatacloud/resources/shorturl.py
+++ b/python/src/acedatacloud/resources/shorturl.py
@@ -1,0 +1,31 @@
+"""Short URL resource (``/shorturl``)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ShortUrl:
+    """Synchronous short URL client."""
+
+    def __init__(self, transport: Any) -> None:
+        self._transport = transport
+
+    def create(self, *, url: str, slug: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"url": url, **kwargs}
+        if slug is not None:
+            body["slug"] = slug
+        return self._transport.request("POST", "/shorturl", json=body)
+
+
+class AsyncShortUrl:
+    """Async short URL client."""
+
+    def __init__(self, transport: Any) -> None:
+        self._transport = transport
+
+    async def create(self, *, url: str, slug: str | None = None, **kwargs: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {"url": url, **kwargs}
+        if slug is not None:
+            body["slug"] = slug
+        return await self._transport.request("POST", "/shorturl", json=body)

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -49,6 +49,8 @@ for await (const chunk of stream) {
 | `client.audio` | Music generation (Suno) |
 | `client.video` | Video generation (Luma, Sora, Veo, etc.) |
 | `client.search` | Web search (Google SERP) |
+| `client.face` | Face analysis & transformation (swap, beautify, age, cartoon) |
+| `client.shorturl` | Short URL creation |
 | `client.tasks` | Cross-service async task polling |
 | `client.files` | File uploads |
 | `client.platform` | Applications, credentials, models management |

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -16,6 +16,8 @@ import { Glm } from './resources/glm';
 import { Veo } from './resources/veo';
 import { Kling } from './resources/kling';
 import { WebExtrator } from './resources/webextrator';
+import { Face } from './resources/face';
+import { ShortUrl } from './resources/shorturl';
 
 export interface AceDataCloudOptions {
   apiToken?: string;
@@ -47,6 +49,8 @@ export class AceDataCloud {
   readonly veo: Veo;
   readonly kling: Kling;
   readonly webextrator: WebExtrator;
+  readonly face: Face;
+  readonly shorturl: ShortUrl;
 
   private transport: Transport;
 
@@ -75,5 +79,7 @@ export class AceDataCloud {
     this.veo = new Veo(this.transport);
     this.kling = new Kling(this.transport);
     this.webextrator = new WebExtrator(this.transport);
+    this.face = new Face(this.transport);
+    this.shorturl = new ShortUrl(this.transport);
   }
 }

--- a/typescript/src/resources/face.ts
+++ b/typescript/src/resources/face.ts
@@ -1,0 +1,46 @@
+/** Face transformation resources (`/face/*`). */
+
+import { Transport } from '../runtime/transport';
+
+export class Face {
+  constructor(private transport: Transport) {}
+
+  private call(action: string, body: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return this.transport.request('POST', `/face/${action}`, { json: body });
+  }
+
+  analyze(opts: { imageUrl: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { imageUrl, ...rest } = opts;
+    return this.call('analyze', { image_url: imageUrl, ...rest });
+  }
+
+  beautify(opts: { imageUrl: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { imageUrl, ...rest } = opts;
+    return this.call('beautify', { image_url: imageUrl, ...rest });
+  }
+
+  changeAge(opts: { imageUrl: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { imageUrl, ...rest } = opts;
+    return this.call('change-age', { image_url: imageUrl, ...rest });
+  }
+
+  changeGender(opts: { imageUrl: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { imageUrl, ...rest } = opts;
+    return this.call('change-gender', { image_url: imageUrl, ...rest });
+  }
+
+  detectLive(opts: { imageUrl: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { imageUrl, ...rest } = opts;
+    return this.call('detect-live', { image_url: imageUrl, ...rest });
+  }
+
+  swap(opts: { sourceImageUrl: string; targetImageUrl: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { sourceImageUrl, targetImageUrl, ...rest } = opts;
+    return this.call('swap', { source_image_url: sourceImageUrl, target_image_url: targetImageUrl, ...rest });
+  }
+
+  cartoon(opts: { imageUrl: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { imageUrl, ...rest } = opts;
+    return this.call('cartoon', { image_url: imageUrl, ...rest });
+  }
+}

--- a/typescript/src/resources/shorturl.ts
+++ b/typescript/src/resources/shorturl.ts
@@ -1,0 +1,14 @@
+/** Short URL resource (`/shorturl`). */
+
+import { Transport } from '../runtime/transport';
+
+export class ShortUrl {
+  constructor(private transport: Transport) {}
+
+  async create(opts: { url: string; slug?: string; [key: string]: unknown }): Promise<Record<string, unknown>> {
+    const { url, slug, ...rest } = opts;
+    const body: Record<string, unknown> = { url, ...rest };
+    if (slug !== undefined) body.slug = slug;
+    return this.transport.request('POST', '/shorturl', { json: body });
+  }
+}


### PR DESCRIPTION
## Summary
Audit of SDK service coverage vs `PlatformBackend/cost/service_api_mapping.json`. Two real services were uncovered everywhere; Go lagged the generation pillars. Filled the low-risk gaps, pattern-consistent, no fabricated endpoints.

### Added
- **face** (`/face/{analyze,beautify,change-age,change-gender,detect-live,swap,cartoon}`) — Python, TS, Go
- **shorturl** (`/shorturl`) — Python, TS, Go
- **Go parity**: added `video`, `audio`, `search` resources (already in py/ts via generic provider modules)

### Coverage matrix
| Service group | py | ts | go (before) | go (after) |
|---|---|---|---|---|
| chat/openai/images/tasks | ✓ | ✓ | ✓ | ✓ |
| video / audio / search | ✓ | ✓ | ✗ | ✓ |
| glm/veo/kling/files/platform/webextrator | ✓ | ✓ | ✗ | (unchanged) |
| face | ✗ | ✗ | ✗ | ✓ |
| shorturl | ✗ | ✗ | ✗ | ✓ |

### Intentionally skipped
- LLM relays (gemini/grok/claude/kimi/deepseek): handled by generic `chat`/`openai`/`aichat`; no per-model module needed.
- Niche gen (qrart/drawai/dreamina/udio/riffusion/maestro/digitalhuman): out of tight scope.
- Go `glm/veo/kling/files/platform/webextrator`: left for a follow-up; provider video/audio/search cover the common cases.

## 🤖 对抗评审
- Reviewer: Codex (`codex exec --sandbox read-only`).
- **RISK (fixed):** Go fish-TTS sent `model` in body; py/ts send it as `model` header → fixed `go/audio.go` to pass it via `ExtraHeaders`.
- Re-review: paths + wiring consistent. VERDICT: CLEAN.
