### PR TITLE
fix: default API clients to X402 gateway

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -114,7 +114,7 @@ except RateLimitError:
 ```python
 client = AceDataCloud(
     api_token="your-token",
-    base_url="https://api.acedata.cloud",       # API gateway
+    base_url="https://x402.acedata.cloud",      # API gateway (default)
     platform_base_url="https://platform.acedata.cloud",  # Management plane
     timeout=300.0,      # Request timeout in seconds
     max_retries=2,      # Retry count for transient errors

--- a/python/src/acedatacloud/_client.py
+++ b/python/src/acedatacloud/_client.py
@@ -26,7 +26,7 @@ from acedatacloud.resources.veo import AsyncVeo, Veo
 from acedatacloud.resources.video import AsyncVideo, Video
 from acedatacloud.resources.webextrator import AsyncWebExtrator, WebExtrator
 
-_API_BASE = "https://api.acedata.cloud"
+_API_BASE = "https://x402.acedata.cloud"
 _PLATFORM_BASE = "https://platform.acedata.cloud"
 
 

--- a/python/src/acedatacloud/_runtime/transport.py
+++ b/python/src/acedatacloud/_runtime/transport.py
@@ -144,8 +144,8 @@ class SyncTransport:
         extra_auth_headers: dict[str, str] = {}
         payment_attempted = False
 
-        last_exc: Exception | None = None
-        for attempt in range(self._max_retries + 1):
+        attempt = 0
+        while True:
             try:
                 resp = self._client.request(
                     method,
@@ -156,21 +156,22 @@ class SyncTransport:
                     timeout=timeout or self._timeout,
                 )
             except httpx.TimeoutException as exc:
-                last_exc = TimeoutError(
+                timeout_error = TimeoutError(
                     message=f"Request timed out: {exc}",
                     status_code=0,
                     code="timeout",
                 )
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     time.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise timeout_error from exc
             except httpx.TransportError as exc:
-                last_exc = TransportError(str(exc))
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     time.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise TransportError(str(exc)) from exc
 
             if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
@@ -197,14 +198,13 @@ class SyncTransport:
                 except Exception:
                     body = {"error": {"code": "unknown", "message": resp.text}}
 
-                if _should_retry(resp.status_code) and attempt < self._max_retries:
+                if not payment_attempted and _should_retry(resp.status_code) and attempt < self._max_retries:
                     time.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
                 raise _map_error(resp.status_code, body)
 
             return resp.json()
-
-        raise last_exc or TransportError("Request failed after retries")
 
     def request_stream(
         self,
@@ -223,30 +223,56 @@ class SyncTransport:
             "accept": "text/event-stream",
             **(extra_headers or {}),
         }
+        extra_auth_headers: dict[str, str] = {}
+        payment_attempted = False
 
-        with self._client.stream(
-            method,
-            url,
-            json=json,
-            headers=headers,
-            timeout=timeout or self._timeout,
-        ) as resp:
-            if resp.status_code >= 400:
-                body_bytes = resp.read()
-                try:
-                    import json as _json
+        while True:
+            with self._client.stream(
+                method,
+                url,
+                json=json,
+                headers={**headers, **extra_auth_headers},
+                timeout=timeout or self._timeout,
+            ) as resp:
+                if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
+                    body_bytes = resp.read()
+                    try:
+                        import json as _json
 
-                    body = _json.loads(body_bytes)
-                except Exception:
-                    body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
-                raise _map_error(resp.status_code, body)
+                        body = _json.loads(body_bytes)
+                    except Exception as exc:
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": body_bytes.decode(errors="replace")}},
+                        ) from exc
+                    accepts = body.get("accepts") or []
+                    if not accepts:
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": "No payment requirements"}},
+                        )
+                    result = self._payment_handler({"url": url, "method": method, "body": json, "accepts": accepts})
+                    extra_auth_headers.update(result.get("headers", {}))
+                    payment_attempted = True
+                    continue
 
-            for line in resp.iter_lines():
-                if line.startswith("data: "):
-                    data = line[6:]
-                    if data == "[DONE]":
-                        return
-                    yield data
+                if resp.status_code >= 400:
+                    body_bytes = resp.read()
+                    try:
+                        import json as _json
+
+                        body = _json.loads(body_bytes)
+                    except Exception:
+                        body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
+                    raise _map_error(resp.status_code, body)
+
+                for line in resp.iter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:]
+                        if data == "[DONE]":
+                            return
+                        yield data
+                return
 
     def upload(
         self,
@@ -335,8 +361,8 @@ class AsyncTransport:
         extra_auth_headers: dict[str, str] = {}
         payment_attempted = False
 
-        last_exc: Exception | None = None
-        for attempt in range(self._max_retries + 1):
+        attempt = 0
+        while True:
             try:
                 resp = await self._client.request(
                     method,
@@ -347,21 +373,22 @@ class AsyncTransport:
                     timeout=timeout or self._timeout,
                 )
             except httpx.TimeoutException as exc:
-                last_exc = TimeoutError(
+                timeout_error = TimeoutError(
                     message=f"Request timed out: {exc}",
                     status_code=0,
                     code="timeout",
                 )
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     await asyncio.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise timeout_error from exc
             except httpx.TransportError as exc:
-                last_exc = TransportError(str(exc))
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     await asyncio.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise TransportError(str(exc)) from exc
 
             if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
@@ -390,14 +417,13 @@ class AsyncTransport:
                 except Exception:
                     body = {"error": {"code": "unknown", "message": resp.text}}
 
-                if _should_retry(resp.status_code) and attempt < self._max_retries:
+                if not payment_attempted and _should_retry(resp.status_code) and attempt < self._max_retries:
                     await asyncio.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
                 raise _map_error(resp.status_code, body)
 
             return resp.json()
-
-        raise last_exc or TransportError("Request failed after retries")
 
     async def request_stream(
         self,
@@ -416,30 +442,60 @@ class AsyncTransport:
             "accept": "text/event-stream",
             **(extra_headers or {}),
         }
+        extra_auth_headers: dict[str, str] = {}
+        payment_attempted = False
 
-        async with self._client.stream(
-            method,
-            url,
-            json=json,
-            headers=headers,
-            timeout=timeout or self._timeout,
-        ) as resp:
-            if resp.status_code >= 400:
-                body_bytes = await resp.aread()
-                try:
-                    import json as _json
+        while True:
+            async with self._client.stream(
+                method,
+                url,
+                json=json,
+                headers={**headers, **extra_auth_headers},
+                timeout=timeout or self._timeout,
+            ) as resp:
+                if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
+                    body_bytes = await resp.aread()
+                    try:
+                        import json as _json
 
-                    body = _json.loads(body_bytes)
-                except Exception:
-                    body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
-                raise _map_error(resp.status_code, body)
+                        body = _json.loads(body_bytes)
+                    except Exception as exc:
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": body_bytes.decode(errors="replace")}},
+                        ) from exc
+                    accepts = body.get("accepts") or []
+                    if not accepts:
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": "No payment requirements"}},
+                        )
+                    handler_result = self._payment_handler(
+                        {"url": url, "method": method, "body": json, "accepts": accepts}
+                    )
+                    if inspect.isawaitable(handler_result):
+                        handler_result = await handler_result
+                    extra_auth_headers.update(handler_result.get("headers", {}))
+                    payment_attempted = True
+                    continue
 
-            async for line in resp.aiter_lines():
-                if line.startswith("data: "):
-                    data = line[6:]
-                    if data == "[DONE]":
-                        return
-                    yield data
+                if resp.status_code >= 400:
+                    body_bytes = await resp.aread()
+                    try:
+                        import json as _json
+
+                        body = _json.loads(body_bytes)
+                    except Exception:
+                        body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
+                    raise _map_error(resp.status_code, body)
+
+                async for line in resp.aiter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:]
+                        if data == "[DONE]":
+                            return
+                        yield data
+                return
 
     async def upload(
         self,

--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -1,6 +1,7 @@
 """Tests for AceDataCloud Python SDK."""
 
 import json
+from unittest.mock import Mock
 
 import httpx
 import pytest
@@ -8,6 +9,7 @@ import respx
 
 from acedatacloud import AceDataCloud, AsyncAceDataCloud
 from acedatacloud._runtime.errors import (
+    APIError,
     AuthenticationError,
     InsufficientBalanceError,
     RateLimitError,
@@ -17,14 +19,120 @@ from acedatacloud._runtime.errors import (
 
 @pytest.fixture
 def client():
-    c = AceDataCloud(api_token="test-token", max_retries=0)
+    c = AceDataCloud(api_token="test-token", base_url="https://api.acedata.cloud", max_retries=0)
     yield c
     c.close()
 
 
 @pytest.fixture
 def async_client():
-    return AsyncAceDataCloud(api_token="test-token", max_retries=0)
+    return AsyncAceDataCloud(api_token="test-token", base_url="https://api.acedata.cloud", max_retries=0)
+
+
+@respx.mock
+def test_default_api_base_uses_x402_host():
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        return_value=httpx.Response(200, json={"choices": []})
+    )
+    client = AceDataCloud(api_token="test-token", max_retries=0)
+
+    client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.called
+    client.close()
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_default_api_base_uses_x402_host():
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        return_value=httpx.Response(200, json={"choices": []})
+    )
+    client = AsyncAceDataCloud(api_token="test-token", max_retries=0)
+
+    await client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.called
+    await client.close()
+
+
+@respx.mock
+def test_x402_payment_retry_does_not_use_retry_budget():
+    payment_handler = Mock(return_value={"headers": {"X-Payment": "signed-payment"}})
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(200, json={"choices": []}),
+        ]
+    )
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.call_count == 2
+    assert route.calls.last.request.headers["X-Payment"] == "signed-payment"
+    client.close()
+
+
+@respx.mock
+def test_x402_paid_request_is_not_retried_with_same_signature():
+    payment_handler = Mock(return_value={"headers": {"X-Payment": "signed-payment"}})
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(500, json={"error": {"message": "upstream failed"}}),
+            httpx.Response(200, json={"choices": []}),
+        ]
+    )
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=2)
+
+    with pytest.raises(APIError, match="upstream failed"):
+        client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.call_count == 2
+    client.close()
+
+
+@respx.mock
+def test_x402_payment_handler_supports_streaming():
+    payment_handler = Mock(return_value={"headers": {"X-Payment": "signed-payment"}})
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(200, text='data: {"delta":"ok"}\n\ndata: [DONE]\n\n'),
+        ]
+    )
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    chunks = list(client.openai.chat.completions.create(model="test", messages=[], stream=True))
+
+    assert chunks == [{"delta": "ok"}]
+    assert route.call_count == 2
+    assert route.calls.last.request.headers["X-Payment"] == "signed-payment"
+    client.close()
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_x402_payment_handler_supports_streaming():
+    async def payment_handler(_context):
+        return {"headers": {"X-Payment": "signed-payment"}}
+
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(200, text='data: {"delta":"ok"}\n\ndata: [DONE]\n\n'),
+        ]
+    )
+    client = AsyncAceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    stream = await client.openai.chat.completions.create(model="test", messages=[], stream=True)
+    chunks = [chunk async for chunk in stream]
+
+    assert chunks == [{"delta": "ok"}]
+    assert route.call_count == 2
+    assert route.calls.last.request.headers["X-Payment"] == "signed-payment"
+    await client.close()
 
 
 # ── OpenAI Chat Completions ──────────────────────────────────────────

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -113,8 +113,8 @@ try {
 ```typescript
 const client = new AceDataCloud({
   apiToken: 'your-token',
-  baseUrl: 'https://api.acedata.cloud',
-  platformBaseUrl: 'https://platform.acedata.cloud',
+  baseURL: 'https://x402.acedata.cloud',
+  platformBaseURL: 'https://platform.acedata.cloud',
   timeout: 300000,    // ms
   maxRetries: 2,
 });

--- a/typescript/src/runtime/transport.ts
+++ b/typescript/src/runtime/transport.ts
@@ -104,7 +104,7 @@ export class Transport {
         code: 'no_token',
       });
     }
-    this.baseURL = (opts.baseURL ?? 'https://api.acedata.cloud').replace(/\/+$/, '');
+    this.baseURL = (opts.baseURL ?? 'https://x402.acedata.cloud').replace(/\/+$/, '');
     this.platformBaseURL = (opts.platformBaseURL ?? 'https://platform.acedata.cloud').replace(/\/+$/, '');
     this.timeout = opts.timeout ?? 300_000;
     this.maxRetries = opts.maxRetries ?? 2;
@@ -144,7 +144,8 @@ export class Transport {
     let lastError: Error | null = null;
     let paymentAttempted = false;
     let extraHeaders: Record<string, string> = {};
-    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+    let attempt = 0;
+    while (true) {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
       try {
@@ -186,8 +187,9 @@ export class Transport {
           } catch {
             body = { error: { code: 'unknown', message: text } };
           }
-          if (RETRY_STATUS_CODES.has(resp.status) && attempt < this.maxRetries) {
+          if (!paymentAttempted && RETRY_STATUS_CODES.has(resp.status) && attempt < this.maxRetries) {
             await sleep(backoffDelay(attempt) * 1000);
+            attempt += 1;
             continue;
           }
           throw mapError(resp.status, body);
@@ -198,13 +200,14 @@ export class Transport {
         clearTimeout(timer);
         if (err instanceof APIError) throw err;
         lastError = err as Error;
-        if (attempt < this.maxRetries) {
+        if (!paymentAttempted && attempt < this.maxRetries) {
           await sleep(backoffDelay(attempt) * 1000);
+          attempt += 1;
           continue;
         }
+        throw lastError;
       }
     }
-    throw lastError ?? new TransportError('Request failed after retries');
   }
 
   async *requestStream(
@@ -214,52 +217,83 @@ export class Transport {
   ): AsyncGenerator<string, void, unknown> {
     const url = `${this.baseURL}${path}`;
     const headers = { ...this.headers, accept: 'text/event-stream' };
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), opts.timeout ?? this.timeout);
+    let paymentAttempted = false;
+    let extraHeaders: Record<string, string> = {};
 
-    try {
-      const resp = await fetch(url, {
-        method,
-        headers,
-        body: opts.json ? JSON.stringify(opts.json) : undefined,
-        signal: controller.signal,
-      });
+    while (true) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), opts.timeout ?? this.timeout);
+      try {
+        const resp = await fetch(url, {
+          method,
+          headers: { ...headers, ...extraHeaders },
+          body: opts.json ? JSON.stringify(opts.json) : undefined,
+          signal: controller.signal,
+        });
 
-      if (resp.status >= 400) {
-        const text = await resp.text();
-        let body: Record<string, unknown>;
-        try {
-          body = JSON.parse(text) as Record<string, unknown>;
-        } catch {
-          body = { error: { code: 'unknown', message: text } };
-        }
-        throw mapError(resp.status, body);
-      }
-
-      if (!resp.body) throw new TransportError('No response body for stream');
-
-      const reader = resp.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6);
-            if (data === '[DONE]') return;
-            yield data;
+        if (resp.status === 402 && this.paymentHandler && !paymentAttempted) {
+          const text = await resp.text();
+          let body: PaymentRequiredBody;
+          try {
+            body = JSON.parse(text) as PaymentRequiredBody;
+          } catch {
+            throw mapError(402, { error: { code: 'invalid_402', message: text } });
           }
+          if (!body.accepts?.length) {
+            throw mapError(402, { error: { code: 'invalid_402', message: 'No payment requirements' } });
+          }
+          const result = await this.paymentHandler({
+            url,
+            method,
+            body: opts.json,
+            accepts: body.accepts,
+          });
+          extraHeaders = { ...extraHeaders, ...result.headers };
+          paymentAttempted = true;
+          continue;
         }
+
+        if (resp.status >= 400) {
+          const text = await resp.text();
+          let body: Record<string, unknown>;
+          try {
+            body = JSON.parse(text) as Record<string, unknown>;
+          } catch {
+            body = { error: { code: 'unknown', message: text } };
+          }
+          throw mapError(resp.status, body);
+        }
+
+        if (!resp.body) throw new TransportError('No response body for stream');
+
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+
+            const lines = buffer.split('\n');
+            buffer = lines.pop() ?? '';
+
+            for (const line of lines) {
+              if (line.startsWith('data: ')) {
+                const data = line.slice(6);
+                if (data === '[DONE]') return;
+                yield data;
+              }
+            }
+          }
+        } finally {
+          await reader.cancel();
+        }
+        return;
+      } finally {
+        clearTimeout(timer);
       }
-    } finally {
-      clearTimeout(timer);
     }
   }
 

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for AceDataCloud TypeScript SDK.
  *
  * These tests run against the live API. Set these in .env (repo root) or environment:
- *   - ACEDATACLOUD_API_TOKEN      — API token for api.acedata.cloud
+ *   - ACEDATACLOUD_API_TOKEN      — API token for x402.acedata.cloud
  *   - ACEDATACLOUD_PLATFORM_TOKEN — Platform token for platform.acedata.cloud (optional)
  *
  * Usage:

--- a/typescript/tests/transport.test.ts
+++ b/typescript/tests/transport.test.ts
@@ -1,0 +1,140 @@
+import { Transport } from '../src/runtime/transport';
+
+describe('Transport API base URL', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses the dedicated X402 host by default', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const transport = new Transport({ apiToken: 'test-token', maxRetries: 0 });
+
+    await transport.request('POST', '/openai/chat/completions', { json: { model: 'test' } });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://x402.acedata.cloud/openai/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('preserves an explicit API base URL override', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const transport = new Transport({
+      apiToken: 'test-token',
+      baseURL: 'https://api.acedata.cloud/',
+      maxRetries: 0,
+    });
+
+    await transport.request('GET', '/openai/models');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.acedata.cloud/openai/models', expect.any(Object));
+  });
+
+  it('retries once with payment headers when maxRetries is zero', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const transport = new Transport({ paymentHandler, maxRetries: 0 });
+
+    await transport.request('POST', '/openai/chat/completions', { json: { model: 'test' } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({ 'X-Payment': 'signed-payment' });
+  });
+
+  it('does not retry a paid request with the same signature', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'upstream failed' } }), { status: 500 })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const transport = new Transport({ paymentHandler, maxRetries: 2 });
+
+    await expect(
+      transport.request('POST', '/openai/chat/completions', { json: { model: 'test' } })
+    ).rejects.toThrow('upstream failed');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries streaming requests with payment headers', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(
+        new Response('data: {"delta":"ok"}\n\ndata: [DONE]\n\n', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      );
+    const transport = new Transport({ paymentHandler, maxRetries: 0 });
+
+    const chunks: string[] = [];
+    for await (const chunk of transport.requestStream('POST', '/openai/chat/completions', {
+      json: { model: 'test', stream: true },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['{"delta":"ok"}']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({ 'X-Payment': 'signed-payment' });
+    expect(fetchMock.mock.calls[1][1]?.signal).not.toBe(fetchMock.mock.calls[0][1]?.signal);
+  });
+
+  it('cancels a paid stream when the consumer exits early', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const cancel = jest.fn();
+    const streamBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: {"delta":"ok"}\n\n'));
+      },
+      cancel,
+    });
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(new Response(streamBody, { status: 200 }));
+    const transport = new Transport({ paymentHandler, maxRetries: 0 });
+
+    for await (const _chunk of transport.requestStream('POST', '/openai/chat/completions', {
+      json: { model: 'test', stream: true },
+    })) {
+      break;
+    }
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- make `https://x402.acedata.cloud` the default API origin for the Python and TypeScript SDKs
- preserve explicit `base_url` / `baseURL` overrides and keep the platform management plane on `https://platform.acedata.cloud`
- make the one paid retry independent of `max_retries` / `maxRetries`, including when configured as zero
- support X402 payment negotiation for sync and async streaming requests
- prevent generic retries from reusing a signed `X-Payment` header
- cancel TypeScript stream readers when consumers exit early
- correct the documented TypeScript option names to `baseURL` and `platformBaseURL`

Go remains unchanged because X402Client currently integrates only with the Python and TypeScript SDKs.

## Validation

- Python: `35 passed, 29 skipped`; Ruff passed
- TypeScript: `14 passed, 27 skipped`; typecheck and package build passed
- live default non-streaming Python SDK + X402Client call, without `base_url`: returned `DEFAULT_OK`, Base exact settlement authorized
- live default streaming call, without `base_url` and with `max_retries=0`: 5 SSE chunks, returned `STREAM_OK`

## Adversarial Review

Reviewer: Codex, 3 rounds

- RISK: payment retry was blocked by `maxRetries=0` in Python/TypeScript -> fixed by separating the one payment retry from transient retry budgets
- RISK: Python/TypeScript streaming bypassed payment handlers -> fixed for sync and async streaming paths
- RISK: transient retries reused the same signed payment header -> fixed by disabling generic retries after payment attachment
- RISK: TypeScript streaming shared one timeout/controller across negotiation and paid stream -> fixed with per-attempt controllers and timers
- RISK: TypeScript early stream exit did not cancel the paid response -> fixed with reader cancellation and a non-terminating stream regression test

All findings were fixed and validated. Round 3 was the configured review cap; its final finding was fixed with executable coverage.
