### PR TITLE
feat(kling): add canonical Omni SDK contract

### DIFF
--- a/python/src/acedatacloud/__init__.py
+++ b/python/src/acedatacloud/__init__.py
@@ -28,6 +28,12 @@ from acedatacloud.resources.aichat import AiChatModel
 from acedatacloud.resources.audio import AudioProvider
 from acedatacloud.resources.glm import GlmModel
 from acedatacloud.resources.images import ImageProvider
+from acedatacloud.resources.kling import (
+    KlingCameraControl,
+    KlingModel,
+    KlingReferenceImage,
+    KlingReferenceVideo,
+)
 from acedatacloud.resources.veo import VeoModel
 from acedatacloud.resources.video import VideoProvider
 
@@ -38,6 +44,10 @@ __all__ = [
     "AudioProvider",
     "GlmModel",
     "ImageProvider",
+    "KlingCameraControl",
+    "KlingModel",
+    "KlingReferenceImage",
+    "KlingReferenceVideo",
     "VideoProvider",
     "VeoModel",
     "AceDataCloudError",

--- a/python/src/acedatacloud/resources/kling.py
+++ b/python/src/acedatacloud/resources/kling.py
@@ -2,8 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
+from urllib.parse import urlparse
 
+KLING_MODELS = (
+    "kling-v1",
+    "kling-v1-6",
+    "kling-v2-master",
+    "kling-v2-1-master",
+    "kling-v2-5-turbo",
+    "kling-v2-6",
+    "kling-v3",
+    "kling-v3-omni",
+    "kling-o1",
+)
 KlingModel = Literal[
     "kling-v1",
     "kling-v1-6",
@@ -13,8 +25,226 @@ KlingModel = Literal[
     "kling-v2-6",
     "kling-v3",
     "kling-v3-omni",
-    "kling-video-o1",
+    "kling-o1",
 ]
+KlingAction = Literal["text2video", "image2video", "extend"]
+KlingMode = Literal["std", "pro", "4k"]
+
+
+class KlingCameraConfig(TypedDict, total=False):
+    horizontal: float
+    vertical: float
+    pan: float
+    tilt: float
+    roll: float
+    zoom: float
+
+
+class KlingCameraControl(TypedDict, total=False):
+    type: Literal["simple", "down_back", "forward_up", "left_turn_forward", "right_turn_forward"]
+    config: KlingCameraConfig
+
+
+class KlingReferenceImage(TypedDict, total=False):
+    image_url: str
+    type: Literal["first_frame", "end_frame"]
+
+
+class KlingReferenceVideo(TypedDict, total=False):
+    video_url: str
+    refer_type: Literal["base", "feature"]
+    keep_original_sound: Literal["yes", "no"]
+
+
+def _is_http_url(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _build_generate_body(
+    *,
+    action: KlingAction,
+    model: KlingModel,
+    mode: KlingMode | None,
+    prompt: str | None,
+    duration: int | None,
+    generate_audio: bool | None,
+    video_id: str | None,
+    cfg_scale: float | None,
+    aspect_ratio: Literal["16:9", "9:16", "1:1"] | None,
+    callback_url: str | None,
+    async_: bool | None,
+    timeout: int | None,
+    end_image_url: str | None,
+    camera_control: KlingCameraControl | None,
+    image_list: list[KlingReferenceImage] | None,
+    video_list: list[KlingReferenceVideo] | None,
+    negative_prompt: str | None,
+    start_image_url: str | None,
+) -> dict[str, Any]:
+    if model not in KLING_MODELS:
+        raise ValueError(f"model must be one of: {', '.join(KLING_MODELS)}")
+    if action not in {"text2video", "image2video", "extend"}:
+        raise ValueError("action must be text2video, image2video, or extend")
+    if image_list is not None and not image_list:
+        raise ValueError("image_list must be non-empty or omitted")
+    if video_list is not None and not video_list:
+        raise ValueError("video_list must be non-empty or omitted")
+
+    is_v3 = model in {"kling-v3", "kling-v3-omni"}
+    has_references = bool(image_list or video_list)
+    if action in {"text2video", "image2video"} and not prompt:
+        raise ValueError("prompt is required for text2video and image2video")
+    if action == "image2video" and not start_image_url:
+        raise ValueError("start_image_url is required for image2video")
+    if action == "extend" and not video_id:
+        raise ValueError("video_id is required for extend")
+    if action == "extend" and model not in {"kling-v1", "kling-v1-6", "kling-v2-5-turbo"}:
+        raise ValueError("extend requires kling-v1, kling-v1-6, or kling-v2-5-turbo")
+    if action == "extend" and has_references:
+        raise ValueError("image_list and video_list are not supported with extend")
+    if end_image_url and not start_image_url:
+        raise ValueError("start_image_url is required with end_image_url")
+    if start_image_url and not _is_http_url(start_image_url):
+        raise ValueError("start_image_url must be an HTTP URL")
+    if end_image_url and not _is_http_url(end_image_url):
+        raise ValueError("end_image_url must be an HTTP URL")
+    if callback_url and not _is_http_url(callback_url):
+        raise ValueError("callback_url must be an HTTP URL")
+    if cfg_scale is not None and (isinstance(cfg_scale, bool) or not 0 <= cfg_scale <= 1):
+        raise ValueError("cfg_scale must be between 0 and 1")
+    if duration is not None and (isinstance(duration, bool) or not isinstance(duration, int)):
+        raise ValueError("duration must be an integer")
+    if is_v3 and duration is not None and not 3 <= duration <= 15:
+        raise ValueError("Kling V3 duration must be between 3 and 15 seconds")
+    if not is_v3 and model != "kling-o1" and duration is not None and duration not in {5, 10}:
+        raise ValueError("This Kling model supports only 5- or 10-second generation")
+    if model == "kling-o1" and duration is not None and duration != 5:
+        raise ValueError("kling-o1 supports only 5-second generation")
+    if model == "kling-o1" and mode is not None and mode not in {"std", "pro"}:
+        raise ValueError("kling-o1 supports only std and pro modes")
+    if mode == "4k" and not is_v3:
+        raise ValueError("4k mode requires kling-v3 or kling-v3-omni")
+    if has_references and model not in {"kling-o1", "kling-v3-omni"}:
+        raise ValueError("Omni references require kling-o1 or kling-v3-omni")
+    if has_references and mode == "4k":
+        raise ValueError("4k cannot be combined with Omni references")
+    if (model == "kling-o1" or has_references) and any(
+        value is not None for value in (negative_prompt, camera_control, cfg_scale)
+    ):
+        raise ValueError("Kling O1 and Omni references do not support negative_prompt, camera_control, or cfg_scale")
+    if model == "kling-o1" and generate_audio:
+        raise ValueError("kling-o1 does not support generate_audio")
+    if generate_audio and not is_v3 and model != "kling-v2-6":
+        raise ValueError("generate_audio requires a V3 model or kling-v2-6 pro mode")
+    if generate_audio and model == "kling-v2-6" and mode != "pro":
+        raise ValueError("kling-v2-6 supports generate_audio only in pro mode")
+    if generate_audio and video_list:
+        raise ValueError("generate_audio cannot be used with video_list")
+    if video_list is not None and len(video_list) != 1:
+        raise ValueError("video_list must contain exactly one reference video")
+
+    for image in image_list or []:
+        if not isinstance(image, dict) or not _is_http_url(image.get("image_url")):
+            raise ValueError("Every reference image requires an HTTP image_url")
+        if image.get("type") is not None and image["type"] not in {"first_frame", "end_frame"}:
+            raise ValueError("Reference image type must be first_frame or end_frame")
+    for video in video_list or []:
+        if not isinstance(video, dict) or not _is_http_url(video.get("video_url")):
+            raise ValueError("Every reference video requires an HTTP video_url")
+        if video.get("refer_type") is not None and video["refer_type"] not in {"base", "feature"}:
+            raise ValueError("Reference video refer_type must be base or feature")
+        if video.get("keep_original_sound") is not None and video["keep_original_sound"] not in {"yes", "no"}:
+            raise ValueError("Reference video keep_original_sound must be yes or no")
+
+    first_frames = int(bool(start_image_url)) + sum(image.get("type") == "first_frame" for image in image_list or [])
+    end_frames = int(bool(end_image_url)) + sum(image.get("type") == "end_frame" for image in image_list or [])
+    if first_frames > 1 or end_frames > 1:
+        raise ValueError("Only one first frame and one end frame are allowed")
+    if end_frames and not first_frames:
+        raise ValueError("A first frame is required with an end frame")
+    if video_list and (video_list[0].get("refer_type") or "base") == "base" and (first_frames or end_frames):
+        raise ValueError("A base reference video cannot be combined with first or end frames")
+    image_count = len(image_list or []) + int(bool(start_image_url)) + int(bool(end_image_url))
+    image_limit = 4 if video_list else 7
+    if image_count > image_limit:
+        raise ValueError(f"Reference images cannot exceed {image_limit} for this request")
+
+    body: dict[str, Any] = {"action": action, "model": model}
+    optional_fields = {
+        "mode": mode,
+        "prompt": prompt,
+        "duration": duration,
+        "generate_audio": generate_audio,
+        "video_id": video_id,
+        "cfg_scale": cfg_scale,
+        "aspect_ratio": aspect_ratio,
+        "callback_url": callback_url,
+        "async": async_,
+        "timeout": timeout,
+        "end_image_url": end_image_url,
+        "camera_control": camera_control,
+        "negative_prompt": negative_prompt,
+        "start_image_url": start_image_url,
+    }
+    body.update({key: value for key, value in optional_fields.items() if value is not None})
+    if image_list is not None:
+        body["image_list"] = [
+            {"image_url": image["image_url"], **({"type": image["type"]} if image.get("type") else {})}
+            for image in image_list
+        ]
+    if video_list is not None:
+        body["video_list"] = [
+            {
+                "video_url": video["video_url"],
+                **({"refer_type": video["refer_type"]} if video.get("refer_type") else {}),
+                **({"keep_original_sound": video["keep_original_sound"]} if video.get("keep_original_sound") else {}),
+            }
+            for video in video_list
+        ]
+    return body
+
+
+def _build_motion_body(
+    *,
+    mode: Literal["std", "pro"],
+    image_url: str,
+    video_url: str,
+    character_orientation: Literal["image", "video"],
+    keep_original_sound: Literal["yes", "no"] | None,
+    prompt: str | None,
+    callback_url: str | None,
+    async_: bool | None,
+) -> dict[str, Any]:
+    if mode not in {"std", "pro"}:
+        raise ValueError("mode must be std or pro")
+    if not _is_http_url(image_url):
+        raise ValueError("image_url must be an HTTP URL")
+    if not _is_http_url(video_url):
+        raise ValueError("video_url must be an HTTP URL")
+    if character_orientation not in {"image", "video"}:
+        raise ValueError("character_orientation must be image or video")
+    if keep_original_sound is not None and keep_original_sound not in {"yes", "no"}:
+        raise ValueError("keep_original_sound must be yes or no")
+    if callback_url and not _is_http_url(callback_url):
+        raise ValueError("callback_url must be an HTTP URL")
+
+    body: dict[str, Any] = {
+        "mode": mode,
+        "image_url": image_url,
+        "video_url": video_url,
+        "character_orientation": character_orientation,
+    }
+    optional_fields = {
+        "keep_original_sound": keep_original_sound,
+        "prompt": prompt,
+        "callback_url": callback_url,
+        "async": async_,
+    }
+    body.update({key: value for key, value in optional_fields.items() if value is not None})
+    return body
 
 
 class Kling:
@@ -26,58 +256,45 @@ class Kling:
     def generate(
         self,
         *,
-        action: Literal["text2video", "image2video", "extend"],
-        mode: Literal["std", "pro", "4k"] | None = None,
-        model: str | None = None,
+        action: KlingAction,
+        model: KlingModel,
+        mode: KlingMode | None = None,
         prompt: str | None = None,
-        duration: Literal[5, 10] | None = None,
+        duration: int | None = None,
         generate_audio: bool | None = None,
         video_id: str | None = None,
         cfg_scale: float | None = None,
         aspect_ratio: Literal["16:9", "9:16", "1:1"] | None = None,
         callback_url: str | None = None,
         async_: bool | None = None,
+        timeout: int | None = None,
         end_image_url: str | None = None,
-        camera_control: str | None = None,
-        element_list: list[Any] | None = None,
-        video_list: list[Any] | None = None,
+        camera_control: KlingCameraControl | None = None,
+        image_list: list[KlingReferenceImage] | None = None,
+        video_list: list[KlingReferenceVideo] | None = None,
         negative_prompt: str | None = None,
         start_image_url: str | None = None,
-        **kwargs: Any,
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {"action": action, **kwargs}
-        if mode is not None:
-            body["mode"] = mode
-        if model is not None:
-            body["model"] = model
-        if prompt is not None:
-            body["prompt"] = prompt
-        if duration is not None:
-            body["duration"] = duration
-        if generate_audio is not None:
-            body["generate_audio"] = generate_audio
-        if video_id is not None:
-            body["video_id"] = video_id
-        if cfg_scale is not None:
-            body["cfg_scale"] = cfg_scale
-        if aspect_ratio is not None:
-            body["aspect_ratio"] = aspect_ratio
-        if callback_url is not None:
-            body["callback_url"] = callback_url
-        if async_ is not None:
-            body["async"] = async_
-        if end_image_url is not None:
-            body["end_image_url"] = end_image_url
-        if camera_control is not None:
-            body["camera_control"] = camera_control
-        if element_list is not None:
-            body["element_list"] = element_list
-        if video_list is not None:
-            body["video_list"] = video_list
-        if negative_prompt is not None:
-            body["negative_prompt"] = negative_prompt
-        if start_image_url is not None:
-            body["start_image_url"] = start_image_url
+        body = _build_generate_body(
+            action=action,
+            model=model,
+            mode=mode,
+            prompt=prompt,
+            duration=duration,
+            generate_audio=generate_audio,
+            video_id=video_id,
+            cfg_scale=cfg_scale,
+            aspect_ratio=aspect_ratio,
+            callback_url=callback_url,
+            async_=async_,
+            timeout=timeout,
+            end_image_url=end_image_url,
+            camera_control=camera_control,
+            image_list=image_list,
+            video_list=video_list,
+            negative_prompt=negative_prompt,
+            start_image_url=start_image_url,
+        )
         return self._transport.request("POST", "/kling/videos", json=body)
 
     def motion(
@@ -91,23 +308,17 @@ class Kling:
         prompt: str | None = None,
         callback_url: str | None = None,
         async_: bool | None = None,
-        **kwargs: Any,
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            "mode": mode,
-            "image_url": image_url,
-            "video_url": video_url,
-            "character_orientation": character_orientation,
-            **kwargs,
-        }
-        if keep_original_sound is not None:
-            body["keep_original_sound"] = keep_original_sound
-        if prompt is not None:
-            body["prompt"] = prompt
-        if callback_url is not None:
-            body["callback_url"] = callback_url
-        if async_ is not None:
-            body["async"] = async_
+        body = _build_motion_body(
+            mode=mode,
+            image_url=image_url,
+            video_url=video_url,
+            character_orientation=character_orientation,
+            keep_original_sound=keep_original_sound,
+            prompt=prompt,
+            callback_url=callback_url,
+            async_=async_,
+        )
         return self._transport.request("POST", "/kling/motion", json=body)
 
 
@@ -120,58 +331,45 @@ class AsyncKling:
     async def generate(
         self,
         *,
-        action: Literal["text2video", "image2video", "extend"],
-        mode: Literal["std", "pro", "4k"] | None = None,
-        model: str | None = None,
+        action: KlingAction,
+        model: KlingModel,
+        mode: KlingMode | None = None,
         prompt: str | None = None,
-        duration: Literal[5, 10] | None = None,
+        duration: int | None = None,
         generate_audio: bool | None = None,
         video_id: str | None = None,
         cfg_scale: float | None = None,
         aspect_ratio: Literal["16:9", "9:16", "1:1"] | None = None,
         callback_url: str | None = None,
         async_: bool | None = None,
+        timeout: int | None = None,
         end_image_url: str | None = None,
-        camera_control: str | None = None,
-        element_list: list[Any] | None = None,
-        video_list: list[Any] | None = None,
+        camera_control: KlingCameraControl | None = None,
+        image_list: list[KlingReferenceImage] | None = None,
+        video_list: list[KlingReferenceVideo] | None = None,
         negative_prompt: str | None = None,
         start_image_url: str | None = None,
-        **kwargs: Any,
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {"action": action, **kwargs}
-        if mode is not None:
-            body["mode"] = mode
-        if model is not None:
-            body["model"] = model
-        if prompt is not None:
-            body["prompt"] = prompt
-        if duration is not None:
-            body["duration"] = duration
-        if generate_audio is not None:
-            body["generate_audio"] = generate_audio
-        if video_id is not None:
-            body["video_id"] = video_id
-        if cfg_scale is not None:
-            body["cfg_scale"] = cfg_scale
-        if aspect_ratio is not None:
-            body["aspect_ratio"] = aspect_ratio
-        if callback_url is not None:
-            body["callback_url"] = callback_url
-        if async_ is not None:
-            body["async"] = async_
-        if end_image_url is not None:
-            body["end_image_url"] = end_image_url
-        if camera_control is not None:
-            body["camera_control"] = camera_control
-        if element_list is not None:
-            body["element_list"] = element_list
-        if video_list is not None:
-            body["video_list"] = video_list
-        if negative_prompt is not None:
-            body["negative_prompt"] = negative_prompt
-        if start_image_url is not None:
-            body["start_image_url"] = start_image_url
+        body = _build_generate_body(
+            action=action,
+            model=model,
+            mode=mode,
+            prompt=prompt,
+            duration=duration,
+            generate_audio=generate_audio,
+            video_id=video_id,
+            cfg_scale=cfg_scale,
+            aspect_ratio=aspect_ratio,
+            callback_url=callback_url,
+            async_=async_,
+            timeout=timeout,
+            end_image_url=end_image_url,
+            camera_control=camera_control,
+            image_list=image_list,
+            video_list=video_list,
+            negative_prompt=negative_prompt,
+            start_image_url=start_image_url,
+        )
         return await self._transport.request("POST", "/kling/videos", json=body)
 
     async def motion(
@@ -185,21 +383,15 @@ class AsyncKling:
         prompt: str | None = None,
         callback_url: str | None = None,
         async_: bool | None = None,
-        **kwargs: Any,
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            "mode": mode,
-            "image_url": image_url,
-            "video_url": video_url,
-            "character_orientation": character_orientation,
-            **kwargs,
-        }
-        if keep_original_sound is not None:
-            body["keep_original_sound"] = keep_original_sound
-        if prompt is not None:
-            body["prompt"] = prompt
-        if callback_url is not None:
-            body["callback_url"] = callback_url
-        if async_ is not None:
-            body["async"] = async_
+        body = _build_motion_body(
+            mode=mode,
+            image_url=image_url,
+            video_url=video_url,
+            character_orientation=character_orientation,
+            keep_original_sound=keep_original_sound,
+            prompt=prompt,
+            callback_url=callback_url,
+            async_=async_,
+        )
         return await self._transport.request("POST", "/kling/motion", json=body)

--- a/python/tests/test_kling.py
+++ b/python/tests/test_kling.py
@@ -1,0 +1,244 @@
+"""Kling resource contract tests."""
+
+from typing import Any
+
+import pytest
+
+from acedatacloud import (
+    KlingCameraControl,
+    KlingModel,
+    KlingReferenceImage,
+    KlingReferenceVideo,
+)
+from acedatacloud.resources.kling import AsyncKling, Kling
+
+
+class SyncTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    def request(self, method: str, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((method, path, json))
+        return {"task_id": "task-kling"}
+
+
+class AsyncTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict[str, Any]]] = []
+
+    async def request(self, method: str, path: str, *, json: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((method, path, json))
+        return {"task_id": "task-kling"}
+
+
+def test_public_kling_types_are_importable() -> None:
+    model: KlingModel = "kling-o1"
+    camera: KlingCameraControl = {"type": "simple"}
+    image: KlingReferenceImage = {"image_url": "https://example.com/ref.jpg"}
+    video: KlingReferenceVideo = {"video_url": "https://example.com/ref.mp4"}
+    assert model == "kling-o1"
+    assert camera["type"] == "simple"
+    assert image["image_url"].endswith("ref.jpg")
+    assert video["video_url"].endswith("ref.mp4")
+
+
+def test_sync_generate_serializes_canonical_omni_request() -> None:
+    transport = SyncTransport()
+    client = Kling(transport)
+
+    result = client.generate(
+        action="text2video",
+        model="kling-o1",
+        prompt="Use the references",
+        mode="std",
+        duration=5,
+        async_=True,
+        timeout=600,
+        image_list=[{"image_url": "https://example.com/ref.jpg"}],
+        video_list=[
+            {
+                "video_url": "https://example.com/ref.mp4",
+                "refer_type": "feature",
+                "keep_original_sound": "yes",
+            }
+        ],
+    )
+
+    assert result == {"task_id": "task-kling"}
+    assert transport.calls == [
+        (
+            "POST",
+            "/kling/videos",
+            {
+                "action": "text2video",
+                "model": "kling-o1",
+                "mode": "std",
+                "prompt": "Use the references",
+                "duration": 5,
+                "async": True,
+                "timeout": 600,
+                "image_list": [{"image_url": "https://example.com/ref.jpg"}],
+                "video_list": [
+                    {
+                        "video_url": "https://example.com/ref.mp4",
+                        "refer_type": "feature",
+                        "keep_original_sound": "yes",
+                    }
+                ],
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_generate_serializes_without_callback() -> None:
+    transport = AsyncTransport()
+    client = AsyncKling(transport)
+
+    await client.generate(
+        action="text2video",
+        model="kling-o1",
+        prompt="test",
+        duration=5,
+        async_=True,
+    )
+
+    assert transport.calls[0][2]["async"] is True
+    assert "callback_url" not in transport.calls[0][2]
+
+
+def test_sync_motion_uses_closed_serialization() -> None:
+    transport = SyncTransport()
+    client = Kling(transport)
+
+    client.motion(
+        mode="pro",
+        image_url="https://example.com/subject.jpg",
+        video_url="https://example.com/motion.mp4",
+        character_orientation="image",
+        keep_original_sound="yes",
+        prompt="follow the motion",
+        async_=True,
+    )
+
+    assert transport.calls == [
+        (
+            "POST",
+            "/kling/motion",
+            {
+                "mode": "pro",
+                "image_url": "https://example.com/subject.jpg",
+                "video_url": "https://example.com/motion.mp4",
+                "character_orientation": "image",
+                "keep_original_sound": "yes",
+                "prompt": "follow the motion",
+                "async": True,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_motion_uses_same_validation() -> None:
+    transport = AsyncTransport()
+    client = AsyncKling(transport)
+
+    with pytest.raises(ValueError, match="video_url must be an HTTP URL"):
+        await client.motion(
+            mode="std",
+            image_url="https://example.com/subject.jpg",
+            video_url="file:///tmp/motion.mp4",
+            character_orientation="video",
+        )
+
+    assert transport.calls == []
+
+
+def test_generate_rejects_invalid_contract_before_transport() -> None:
+    transport = SyncTransport()
+    client = Kling(transport)
+
+    with pytest.raises(ValueError, match="model must be one of"):
+        client.generate(action="text2video", model="unknown-model", prompt="test")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="image_list must be non-empty"):
+        client.generate(action="text2video", model="kling-o1", prompt="test", image_list=[])
+    with pytest.raises(ValueError, match="base reference video"):
+        client.generate(
+            action="image2video",
+            model="kling-v3-omni",
+            prompt="test",
+            start_image_url="https://example.com/start.jpg",
+            video_list=[{"video_url": "https://example.com/ref.mp4", "refer_type": "base"}],
+        )
+    with pytest.raises(ValueError, match="callback_url must be an HTTP URL"):
+        client.generate(
+            action="text2video",
+            model="kling-v3",
+            prompt="test",
+            callback_url="not-a-url",
+        )
+
+    assert transport.calls == []
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        ({"model": "kling-o1", "duration": 10}, "only 5-second"),
+        ({"model": "kling-o1", "mode": "4k"}, "only std and pro"),
+        ({"model": "kling-o1", "generate_audio": True}, "does not support generate_audio"),
+        (
+            {"model": "kling-v3", "image_list": [{"image_url": "https://example.com/ref.jpg"}]},
+            "Omni references require",
+        ),
+        ({"action": "extend", "model": "kling-v3", "video_id": "video-1", "prompt": None}, "extend requires"),
+        (
+            {
+                "model": "kling-o1",
+                "image_list": [{"image_url": "https://example.com/ref.jpg", "type": "invalid"}],
+            },
+            "type must be first_frame or end_frame",
+        ),
+        (
+            {
+                "model": "kling-o1",
+                "video_list": [{"video_url": "https://example.com/ref.mp4", "refer_type": "invalid"}],
+            },
+            "refer_type must be base or feature",
+        ),
+        (
+            {
+                "model": "kling-o1",
+                "video_list": [
+                    {
+                        "video_url": "https://example.com/ref.mp4",
+                        "refer_type": "feature",
+                        "keep_original_sound": "invalid",
+                    }
+                ],
+            },
+            "keep_original_sound must be yes or no",
+        ),
+        (
+            {
+                "model": "kling-o1",
+                "image_list": [{"image_url": f"https://example.com/ref-{index}.jpg"} for index in range(8)],
+            },
+            "cannot exceed 7",
+        ),
+    ],
+)
+def test_generate_rejects_model_and_reference_constraints(options: dict[str, Any], message: str) -> None:
+    transport = SyncTransport()
+    client = Kling(transport)
+    request = {
+        "action": "text2video",
+        "model": "kling-o1",
+        "prompt": "test",
+        **options,
+    }
+
+    with pytest.raises(ValueError, match=message):
+        client.generate(**request)  # type: ignore[arg-type]
+
+    assert transport.calls == []

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -31,5 +31,11 @@ export type { GlmModel } from './resources/glm';
 export type { ImageProvider } from './resources/images';
 export type { VideoProvider } from './resources/video';
 export type { VeoModel } from './resources/veo';
-export type { KlingModel } from './resources/kling';
+export type {
+  KlingCameraControl,
+  KlingGenerateOptions,
+  KlingModel,
+  KlingReferenceImage,
+  KlingReferenceVideo,
+} from './resources/kling';
 export type { AudioProvider } from './resources/audio';

--- a/typescript/src/resources/kling.ts
+++ b/typescript/src/resources/kling.ts
@@ -2,41 +2,200 @@
 
 import { Transport } from '../runtime/transport';
 
-export type KlingModel =
-  | 'kling-v1'
-  | 'kling-v1-6'
-  | 'kling-v2-master'
-  | 'kling-v2-1-master'
-  | 'kling-v2-5-turbo'
-  | 'kling-v2-6'
-  | 'kling-v3'
-  | 'kling-v3-omni'
-  | 'kling-video-o1'
-  | (string & {});
+export const KLING_MODELS = [
+  'kling-v1',
+  'kling-v1-6',
+  'kling-v2-master',
+  'kling-v2-1-master',
+  'kling-v2-5-turbo',
+  'kling-v2-6',
+  'kling-v3',
+  'kling-v3-omni',
+  'kling-o1',
+] as const;
+
+export type KlingModel = (typeof KLING_MODELS)[number];
+
+export interface KlingCameraControl {
+  type: 'simple' | 'down_back' | 'forward_up' | 'left_turn_forward' | 'right_turn_forward';
+  config?: {
+    horizontal?: number;
+    vertical?: number;
+    pan?: number;
+    tilt?: number;
+    roll?: number;
+    zoom?: number;
+  };
+}
+
+export interface KlingReferenceImage {
+  imageUrl: string;
+  type?: 'first_frame' | 'end_frame';
+}
+
+export interface KlingReferenceVideo {
+  videoUrl: string;
+  referType?: 'base' | 'feature';
+  keepOriginalSound?: 'yes' | 'no';
+}
+
+export interface KlingGenerateOptions {
+  action: 'text2video' | 'image2video' | 'extend';
+  mode?: 'std' | 'pro' | '4k';
+  model: KlingModel;
+  prompt?: string;
+  duration?: number;
+  generateAudio?: boolean;
+  videoId?: string;
+  cfgScale?: number;
+  aspectRatio?: '16:9' | '9:16' | '1:1';
+  callbackUrl?: string;
+  async?: boolean;
+  timeout?: number;
+  endImageUrl?: string;
+  cameraControl?: KlingCameraControl;
+  imageList?: KlingReferenceImage[];
+  videoList?: KlingReferenceVideo[];
+  negativePrompt?: string;
+  startImageUrl?: string;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function validateGenerateOptions(opts: KlingGenerateOptions): void {
+  if (!KLING_MODELS.includes(opts.model)) {
+    throw new Error(`model must be one of: ${KLING_MODELS.join(', ')}`);
+  }
+  const isV3 = opts.model === 'kling-v3' || opts.model === 'kling-v3-omni';
+  const hasReferences = Boolean(opts.imageList?.length || opts.videoList?.length);
+
+  if (opts.imageList !== undefined && opts.imageList.length === 0) {
+    throw new Error('imageList must be non-empty or omitted');
+  }
+  if (opts.videoList !== undefined && opts.videoList.length === 0) {
+    throw new Error('videoList must be non-empty or omitted');
+  }
+
+  if ((opts.action === 'text2video' || opts.action === 'image2video') && !opts.prompt) {
+    throw new Error('prompt is required for text2video and image2video');
+  }
+  if (opts.action === 'image2video' && !opts.startImageUrl) {
+    throw new Error('startImageUrl is required for image2video');
+  }
+  if (opts.action === 'extend' && !opts.videoId) {
+    throw new Error('videoId is required for extend');
+  }
+  if (opts.endImageUrl && !opts.startImageUrl) {
+    throw new Error('startImageUrl is required with endImageUrl');
+  }
+  if (opts.startImageUrl && !isHttpUrl(opts.startImageUrl)) {
+    throw new Error('startImageUrl must be an HTTP URL');
+  }
+  if (opts.endImageUrl && !isHttpUrl(opts.endImageUrl)) {
+    throw new Error('endImageUrl must be an HTTP URL');
+  }
+  if (opts.callbackUrl && !isHttpUrl(opts.callbackUrl)) {
+    throw new Error('callbackUrl must be an HTTP URL');
+  }
+  if (opts.cfgScale !== undefined && (opts.cfgScale < 0 || opts.cfgScale > 1)) {
+    throw new Error('cfgScale must be between 0 and 1');
+  }
+  if (opts.duration !== undefined && !Number.isInteger(opts.duration)) {
+    throw new Error('duration must be an integer');
+  }
+  if (isV3 && opts.duration !== undefined && (opts.duration < 3 || opts.duration > 15)) {
+    throw new Error('Kling V3 duration must be between 3 and 15 seconds');
+  }
+  if (!isV3 && opts.model !== 'kling-o1' && opts.duration !== undefined && ![5, 10].includes(opts.duration)) {
+    throw new Error('This Kling model supports only 5- or 10-second generation');
+  }
+  if (opts.model === 'kling-o1' && opts.duration !== undefined && opts.duration !== 5) {
+    throw new Error('kling-o1 supports only 5-second generation');
+  }
+  if (opts.model === 'kling-o1' && opts.mode !== undefined && !['std', 'pro'].includes(opts.mode)) {
+    throw new Error('kling-o1 supports only std and pro modes');
+  }
+  if (opts.mode === '4k' && !isV3) {
+    throw new Error('4k mode requires kling-v3 or kling-v3-omni');
+  }
+  if (opts.action === 'extend' && !['kling-v1', 'kling-v1-6', 'kling-v2-5-turbo'].includes(opts.model)) {
+    throw new Error('extend requires kling-v1, kling-v1-6, or kling-v2-5-turbo');
+  }
+  if (opts.action === 'extend' && hasReferences) {
+    throw new Error('imageList and videoList are not supported with extend');
+  }
+  if (hasReferences && opts.model !== 'kling-o1' && opts.model !== 'kling-v3-omni') {
+    throw new Error('Omni references require kling-o1 or kling-v3-omni');
+  }
+  if (hasReferences && opts.mode === '4k') {
+    throw new Error('4k cannot be combined with Omni references');
+  }
+  if ((opts.model === 'kling-o1' || hasReferences) && (opts.negativePrompt !== undefined || opts.cameraControl !== undefined || opts.cfgScale !== undefined)) {
+    throw new Error('Kling O1 and Omni references do not support negativePrompt, cameraControl, or cfgScale');
+  }
+  if (opts.model === 'kling-o1' && opts.generateAudio) {
+    throw new Error('kling-o1 does not support generateAudio');
+  }
+  if (opts.generateAudio && !isV3 && opts.model !== 'kling-v2-6') {
+    throw new Error('generateAudio requires a V3 model or kling-v2-6 pro mode');
+  }
+  if (opts.generateAudio && opts.model === 'kling-v2-6' && opts.mode !== 'pro') {
+    throw new Error('kling-v2-6 supports generateAudio only in pro mode');
+  }
+  if (opts.generateAudio && opts.videoList?.length) {
+    throw new Error('generateAudio cannot be used with videoList');
+  }
+  if (opts.videoList && (opts.videoList.length === 0 || opts.videoList.length > 1)) {
+    throw new Error('videoList must contain exactly one reference video');
+  }
+
+  for (const image of opts.imageList ?? []) {
+    if (!isHttpUrl(image.imageUrl)) throw new Error('Every reference image requires an HTTP imageUrl');
+    if (image.type !== undefined && !['first_frame', 'end_frame'].includes(image.type)) {
+      throw new Error('Reference image type must be first_frame or end_frame');
+    }
+  }
+  for (const video of opts.videoList ?? []) {
+    if (!isHttpUrl(video.videoUrl)) throw new Error('Every reference video requires an HTTP videoUrl');
+    if (video.referType !== undefined && !['base', 'feature'].includes(video.referType)) {
+      throw new Error('Reference video referType must be base or feature');
+    }
+    if (video.keepOriginalSound !== undefined && !['yes', 'no'].includes(video.keepOriginalSound)) {
+      throw new Error('Reference video keepOriginalSound must be yes or no');
+    }
+  }
+
+  const firstFrames = Number(Boolean(opts.startImageUrl)) + (opts.imageList ?? []).filter((item) => item.type === 'first_frame').length;
+  const endFrames = Number(Boolean(opts.endImageUrl)) + (opts.imageList ?? []).filter((item) => item.type === 'end_frame').length;
+  if (firstFrames > 1 || endFrames > 1) {
+    throw new Error('Only one first frame and one end frame are allowed');
+  }
+  if (endFrames > 0 && firstFrames === 0) {
+    throw new Error('A first frame is required with an end frame');
+  }
+  if ((opts.videoList?.[0]?.referType ?? 'base') === 'base' && opts.videoList?.length && (firstFrames > 0 || endFrames > 0)) {
+    throw new Error('A base reference video cannot be combined with first or end frames');
+  }
+
+  const imageCount = (opts.imageList?.length ?? 0) + Number(Boolean(opts.startImageUrl)) + Number(Boolean(opts.endImageUrl));
+  const imageLimit = opts.videoList?.length ? 4 : 7;
+  if (imageCount > imageLimit) {
+    throw new Error(`Reference images cannot exceed ${imageLimit} for this request`);
+  }
+}
 
 export class Kling {
   constructor(private transport: Transport) {}
 
-  async generate(opts: {
-    action: 'text2video' | 'image2video' | 'extend';
-    mode?: 'std' | 'pro' | '4k';
-    model?: KlingModel;
-    prompt?: string;
-    duration?: 5 | 10;
-    generateAudio?: boolean;
-    videoId?: string;
-    cfgScale?: number;
-    aspectRatio?: '16:9' | '9:16' | '1:1';
-    callbackUrl?: string;
-    async?: boolean;
-    endImageUrl?: string;
-    cameraControl?: string;
-    elementList?: unknown[];
-    videoList?: unknown[];
-    negativePrompt?: string;
-    startImageUrl?: string;
-    [key: string]: unknown;
-  }): Promise<Record<string, unknown>> {
+  async generate(opts: KlingGenerateOptions): Promise<Record<string, unknown>> {
+    validateGenerateOptions(opts);
     const {
       action,
       mode,
@@ -48,15 +207,16 @@ export class Kling {
       cfgScale,
       aspectRatio,
       callbackUrl,
+      async: asyncMode,
+      timeout,
       endImageUrl,
       cameraControl,
-      elementList,
+      imageList,
       videoList,
       negativePrompt,
       startImageUrl,
-      ...rest
     } = opts;
-    const body: Record<string, unknown> = { action, ...rest };
+    const body: Record<string, unknown> = { action };
     if (mode !== undefined) body.mode = mode;
     if (model !== undefined) body.model = model;
     if (prompt !== undefined) body.prompt = prompt;
@@ -66,10 +226,20 @@ export class Kling {
     if (cfgScale !== undefined) body.cfg_scale = cfgScale;
     if (aspectRatio !== undefined) body.aspect_ratio = aspectRatio;
     if (callbackUrl !== undefined) body.callback_url = callbackUrl;
+    if (asyncMode !== undefined) body.async = asyncMode;
+    if (timeout !== undefined) body.timeout = timeout;
     if (endImageUrl !== undefined) body.end_image_url = endImageUrl;
     if (cameraControl !== undefined) body.camera_control = cameraControl;
-    if (elementList !== undefined) body.element_list = elementList;
-    if (videoList !== undefined) body.video_list = videoList;
+    if (imageList !== undefined) {
+      body.image_list = imageList.map(({ imageUrl, type }) => ({ image_url: imageUrl, ...(type ? { type } : {}) }));
+    }
+    if (videoList !== undefined) {
+      body.video_list = videoList.map(({ videoUrl, referType, keepOriginalSound }) => ({
+        video_url: videoUrl,
+        ...(referType ? { refer_type: referType } : {}),
+        ...(keepOriginalSound ? { keep_original_sound: keepOriginalSound } : {}),
+      }));
+    }
     if (negativePrompt !== undefined) body.negative_prompt = negativePrompt;
     if (startImageUrl !== undefined) body.start_image_url = startImageUrl;
     return this.transport.request('POST', '/kling/videos', { json: body });
@@ -84,19 +254,28 @@ export class Kling {
     prompt?: string;
     callbackUrl?: string;
     async?: boolean;
-    [key: string]: unknown;
   }): Promise<Record<string, unknown>> {
-    const { mode, imageUrl, videoUrl, characterOrientation, keepOriginalSound, prompt, callbackUrl, ...rest } = opts;
+    const { mode, imageUrl, videoUrl, characterOrientation, keepOriginalSound, prompt, callbackUrl } = opts;
+    if (!['std', 'pro'].includes(mode)) throw new Error('mode must be std or pro');
+    if (!isHttpUrl(imageUrl)) throw new Error('imageUrl must be an HTTP URL');
+    if (!isHttpUrl(videoUrl)) throw new Error('videoUrl must be an HTTP URL');
+    if (!['image', 'video'].includes(characterOrientation)) {
+      throw new Error('characterOrientation must be image or video');
+    }
+    if (keepOriginalSound !== undefined && !['yes', 'no'].includes(keepOriginalSound)) {
+      throw new Error('keepOriginalSound must be yes or no');
+    }
+    if (callbackUrl && !isHttpUrl(callbackUrl)) throw new Error('callbackUrl must be an HTTP URL');
     const body: Record<string, unknown> = {
       mode,
       image_url: imageUrl,
       video_url: videoUrl,
       character_orientation: characterOrientation,
-      ...rest,
     };
     if (keepOriginalSound !== undefined) body.keep_original_sound = keepOriginalSound;
     if (prompt !== undefined) body.prompt = prompt;
     if (callbackUrl !== undefined) body.callback_url = callbackUrl;
+    if (opts.async !== undefined) body.async = opts.async;
     return this.transport.request('POST', '/kling/motion', { json: body });
   }
 }

--- a/typescript/tests/kling.test.ts
+++ b/typescript/tests/kling.test.ts
@@ -1,0 +1,237 @@
+import { Kling } from '../src/resources/kling';
+
+describe('Kling resource', () => {
+  it('serializes canonical Omni references and async polling', async () => {
+    const request = jest.fn().mockResolvedValue({ task_id: 'task-kling' });
+    const kling = new Kling({ request } as any);
+
+    await kling.generate({
+      action: 'text2video',
+      model: 'kling-o1',
+      prompt: 'Use the references',
+      mode: 'std',
+      duration: 5,
+      async: true,
+      timeout: 600,
+      imageList: [{ imageUrl: 'https://example.com/ref.jpg' }],
+      videoList: [
+        {
+          videoUrl: 'https://example.com/ref.mp4',
+          referType: 'feature',
+          keepOriginalSound: 'yes',
+        },
+      ],
+    });
+
+    expect(request).toHaveBeenCalledWith('POST', '/kling/videos', {
+      json: {
+        action: 'text2video',
+        model: 'kling-o1',
+        prompt: 'Use the references',
+        mode: 'std',
+        duration: 5,
+        async: true,
+        timeout: 600,
+        image_list: [{ image_url: 'https://example.com/ref.jpg' }],
+        video_list: [
+          {
+            video_url: 'https://example.com/ref.mp4',
+            refer_type: 'feature',
+            keep_original_sound: 'yes',
+          },
+        ],
+      },
+    });
+  });
+
+  it('rejects references on non-Omni models before transport', async () => {
+    const request = jest.fn();
+    const kling = new Kling({ request } as any);
+
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-v3',
+        prompt: 'test',
+        imageList: [{ imageUrl: 'https://example.com/ref.jpg' }],
+      })
+    ).rejects.toThrow('Omni references require');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown runtime model before transport', async () => {
+    const request = jest.fn();
+    const kling = new Kling({ request } as any);
+
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'unknown-model',
+        prompt: 'test',
+      } as any)
+    ).rejects.toThrow('model must be one of');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid O1 duration and duplicate first frames', async () => {
+    const kling = new Kling({ request: jest.fn() } as any);
+
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-o1',
+        prompt: 'test',
+        duration: 10,
+      })
+    ).rejects.toThrow('only 5-second');
+
+    await expect(
+      kling.generate({
+        action: 'image2video',
+        model: 'kling-v3-omni',
+        prompt: 'test',
+        startImageUrl: 'https://example.com/start.jpg',
+        imageList: [{ imageUrl: 'https://example.com/other.jpg', type: 'first_frame' }],
+      })
+    ).rejects.toThrow('Only one first frame');
+  });
+
+  it('rejects extend on unsupported models', async () => {
+    const kling = new Kling({ request: jest.fn() } as any);
+
+    await expect(
+      kling.generate({
+        action: 'extend',
+        model: 'kling-v3',
+        videoId: 'video-1',
+      })
+    ).rejects.toThrow('extend requires');
+  });
+
+  it('rejects a base reference video combined with frames', async () => {
+    const kling = new Kling({ request: jest.fn() } as any);
+
+    await expect(
+      kling.generate({
+        action: 'image2video',
+        model: 'kling-v3-omni',
+        prompt: 'test',
+        startImageUrl: 'https://example.com/start.jpg',
+        videoList: [{ videoUrl: 'https://example.com/base.mp4', referType: 'base' }],
+      })
+    ).rejects.toThrow('base reference video');
+  });
+
+  it('rejects explicit empty reference arrays before transport', async () => {
+    const request = jest.fn();
+    const kling = new Kling({ request } as any);
+
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-o1',
+        prompt: 'test',
+        imageList: [],
+      })
+    ).rejects.toThrow('imageList must be non-empty');
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-o1',
+        prompt: 'test',
+        videoList: [],
+      })
+    ).rejects.toThrow('videoList must be non-empty');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('serializes motion from an explicit closed contract', async () => {
+    const request = jest.fn().mockResolvedValue({ task_id: 'task-motion' });
+    const kling = new Kling({ request } as any);
+
+    await kling.motion({
+      mode: 'pro',
+      imageUrl: 'https://example.com/subject.jpg',
+      videoUrl: 'https://example.com/motion.mp4',
+      characterOrientation: 'image',
+      keepOriginalSound: 'yes',
+      prompt: 'follow the motion',
+      async: true,
+    });
+
+    expect(request).toHaveBeenCalledWith('POST', '/kling/motion', {
+      json: {
+        mode: 'pro',
+        image_url: 'https://example.com/subject.jpg',
+        video_url: 'https://example.com/motion.mp4',
+        character_orientation: 'image',
+        keep_original_sound: 'yes',
+        prompt: 'follow the motion',
+        async: true,
+      },
+    });
+  });
+
+  it('rejects malformed motion and callback URLs before transport', async () => {
+    const request = jest.fn();
+    const kling = new Kling({ request } as any);
+
+    await expect(
+      kling.motion({
+        mode: 'std',
+        imageUrl: 'https://example.com/subject.jpg',
+        videoUrl: 'file:///tmp/motion.mp4',
+        characterOrientation: 'video',
+      })
+    ).rejects.toThrow('videoUrl must be an HTTP URL');
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-v3',
+        prompt: 'test',
+        callbackUrl: 'not-a-url',
+      })
+    ).rejects.toThrow('callbackUrl must be an HTTP URL');
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid reference enums and audio with video before transport', async () => {
+    const request = jest.fn();
+    const kling = new Kling({ request } as any);
+
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-o1',
+        prompt: 'test',
+        imageList: [{ imageUrl: 'https://example.com/ref.jpg', type: 'invalid' }],
+      } as any)
+    ).rejects.toThrow('type must be first_frame or end_frame');
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-o1',
+        prompt: 'test',
+        videoList: [{ videoUrl: 'https://example.com/ref.mp4', referType: 'invalid' }],
+      } as any)
+    ).rejects.toThrow('referType must be base or feature');
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-o1',
+        prompt: 'test',
+        videoList: [{ videoUrl: 'https://example.com/ref.mp4', referType: 'feature', keepOriginalSound: 'invalid' }],
+      } as any)
+    ).rejects.toThrow('keepOriginalSound must be yes or no');
+    await expect(
+      kling.generate({
+        action: 'text2video',
+        model: 'kling-v3-omni',
+        prompt: 'test',
+        generateAudio: true,
+        videoList: [{ videoUrl: 'https://example.com/ref.mp4', referType: 'feature' }],
+      })
+    ).rejects.toThrow('generateAudio cannot be used with videoList');
+    expect(request).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- expose the canonical `kling-o1` model across Python and TypeScript SDKs
- add typed camera, image-reference, and video-reference contracts with explicit snake_case serialization
- remove the unsafe Element surface and close unknown-field forwarding in generation and motion APIs
- enforce the same model, mode, duration, frame, reference, audio, and extend constraints as PlatformService PR 1500
- preserve async polling without requiring a callback URL

## Validation
- Python: 44 passed, 29 integration tests skipped
- Python: Ruff check and format check
- Python 3.9 compileall
- Python wheel build via `uv build --wheel`
- TypeScript: 18 passed, 27 integration tests skipped
- TypeScript strict typecheck and package build
- clean-break scan: no `kling-video-o1`, `element_list`, or `elementList`
- `git diff --check`

## Rollout dependency
Publish this SDK only after PlatformService PR 1500 and PlatformBackend PR 1007 are deployed, canonical billing is synced, and the controlled live canary succeeds.

## Adversarial review
Reviewer: read-only Explore subagent, multiple rounds.
- removed unknown-field leakage from Python `**kwargs` and TypeScript index/spread motion contracts
- added symmetric URL and runtime enum validation for motion and callbacks
- added Python/TypeScript parity tests for serialization and invalid combinations
- expanded review to both language SDKs and closed the old Python `element_list` surface
- final verdict: CLEAN
