### PR TITLE
fix: default API clients to X402 gateway

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -114,7 +114,7 @@ except RateLimitError:
 ```python
 client = AceDataCloud(
     api_token="your-token",
-    base_url="https://api.acedata.cloud",       # API gateway
+    base_url="https://x402.acedata.cloud",      # API gateway (default)
     platform_base_url="https://platform.acedata.cloud",  # Management plane
     timeout=300.0,      # Request timeout in seconds
     max_retries=2,      # Retry count for transient errors
@@ -147,12 +147,25 @@ result = client.openai.chat.completions.create(
 )
 ```
 
-The `AsyncAceDataCloud` client accepts either a synchronous or
-asynchronous handler, so you can plug in wallet SDKs that use
-`asyncio`. A ready-made x402 signer for Python is not shipped yet
-(there is a TypeScript implementation in
-[`@acedatacloud/x402-client`](https://github.com/AceDataCloud/X402Client)
-— contributions for a Python port are welcome).
+The `AsyncAceDataCloud` client accepts either a synchronous or asynchronous
+handler. For a ready-made signer, install `acedatacloud-x402` and pass its
+handler directly:
+
+```python
+from acedatacloud import AceDataCloud
+from acedatacloud_x402 import EVMAccountSigner, create_x402_payment_handler
+
+client = AceDataCloud(
+    payment_handler=create_x402_payment_handler(
+        network="base",
+        evm_signer=EVMAccountSigner.from_private_key("0x..."),
+        prefer_scheme="upto",
+    )
+)
+```
+
+See [`AceDataCloud/X402Client`](https://github.com/AceDataCloud/X402Client) for
+Base, Solana, and SKALE setup details.
 
 ## License
 

--- a/python/src/acedatacloud/_client.py
+++ b/python/src/acedatacloud/_client.py
@@ -26,7 +26,7 @@ from acedatacloud.resources.veo import AsyncVeo, Veo
 from acedatacloud.resources.video import AsyncVideo, Video
 from acedatacloud.resources.webextrator import AsyncWebExtrator, WebExtrator
 
-_API_BASE = "https://api.acedata.cloud"
+_API_BASE = "https://x402.acedata.cloud"
 _PLATFORM_BASE = "https://platform.acedata.cloud"
 
 

--- a/python/src/acedatacloud/_runtime/transport.py
+++ b/python/src/acedatacloud/_runtime/transport.py
@@ -144,8 +144,8 @@ class SyncTransport:
         extra_auth_headers: dict[str, str] = {}
         payment_attempted = False
 
-        last_exc: Exception | None = None
-        for attempt in range(self._max_retries + 1):
+        attempt = 0
+        while True:
             try:
                 resp = self._client.request(
                     method,
@@ -156,21 +156,22 @@ class SyncTransport:
                     timeout=timeout or self._timeout,
                 )
             except httpx.TimeoutException as exc:
-                last_exc = TimeoutError(
+                timeout_error = TimeoutError(
                     message=f"Request timed out: {exc}",
                     status_code=0,
                     code="timeout",
                 )
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     time.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise timeout_error from exc
             except httpx.TransportError as exc:
-                last_exc = TransportError(str(exc))
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     time.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise TransportError(str(exc)) from exc
 
             if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
@@ -180,8 +181,8 @@ class SyncTransport:
                         402,
                         {"error": {"code": "invalid_402", "message": resp.text}},
                     ) from exc
-                accepts = body.get("accepts") or []
-                if not accepts:
+                accepts = body.get("accepts") if isinstance(body, dict) else None
+                if not isinstance(accepts, list) or not accepts or not all(isinstance(item, dict) for item in accepts):
                     raise _map_error(
                         402,
                         {"error": {"code": "invalid_402", "message": "No payment requirements"}},
@@ -197,14 +198,13 @@ class SyncTransport:
                 except Exception:
                     body = {"error": {"code": "unknown", "message": resp.text}}
 
-                if _should_retry(resp.status_code) and attempt < self._max_retries:
+                if not payment_attempted and _should_retry(resp.status_code) and attempt < self._max_retries:
                     time.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
                 raise _map_error(resp.status_code, body)
 
             return resp.json()
-
-        raise last_exc or TransportError("Request failed after retries")
 
     def request_stream(
         self,
@@ -223,30 +223,60 @@ class SyncTransport:
             "accept": "text/event-stream",
             **(extra_headers or {}),
         }
+        extra_auth_headers: dict[str, str] = {}
+        payment_attempted = False
 
-        with self._client.stream(
-            method,
-            url,
-            json=json,
-            headers=headers,
-            timeout=timeout or self._timeout,
-        ) as resp:
-            if resp.status_code >= 400:
-                body_bytes = resp.read()
-                try:
-                    import json as _json
+        while True:
+            with self._client.stream(
+                method,
+                url,
+                json=json,
+                headers={**headers, **extra_auth_headers},
+                timeout=timeout or self._timeout,
+            ) as resp:
+                if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
+                    body_bytes = resp.read()
+                    try:
+                        import json as _json
 
-                    body = _json.loads(body_bytes)
-                except Exception:
-                    body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
-                raise _map_error(resp.status_code, body)
+                        body = _json.loads(body_bytes)
+                    except Exception as exc:
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": body_bytes.decode(errors="replace")}},
+                        ) from exc
+                    accepts = body.get("accepts") if isinstance(body, dict) else None
+                    if (
+                        not isinstance(accepts, list)
+                        or not accepts
+                        or not all(isinstance(item, dict) for item in accepts)
+                    ):
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": "No payment requirements"}},
+                        )
+                    result = self._payment_handler({"url": url, "method": method, "body": json, "accepts": accepts})
+                    extra_auth_headers.update(result.get("headers", {}))
+                    payment_attempted = True
+                    continue
 
-            for line in resp.iter_lines():
-                if line.startswith("data: "):
-                    data = line[6:]
-                    if data == "[DONE]":
-                        return
-                    yield data
+                if resp.status_code >= 400:
+                    body_bytes = resp.read()
+                    try:
+                        import json as _json
+
+                        body = _json.loads(body_bytes)
+                    except Exception:
+                        body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
+                    raise _map_error(resp.status_code, body)
+
+                for line in resp.iter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:]
+                        if data == "[DONE]":
+                            return
+                        yield data
+                return
 
     def upload(
         self,
@@ -335,8 +365,8 @@ class AsyncTransport:
         extra_auth_headers: dict[str, str] = {}
         payment_attempted = False
 
-        last_exc: Exception | None = None
-        for attempt in range(self._max_retries + 1):
+        attempt = 0
+        while True:
             try:
                 resp = await self._client.request(
                     method,
@@ -347,21 +377,22 @@ class AsyncTransport:
                     timeout=timeout or self._timeout,
                 )
             except httpx.TimeoutException as exc:
-                last_exc = TimeoutError(
+                timeout_error = TimeoutError(
                     message=f"Request timed out: {exc}",
                     status_code=0,
                     code="timeout",
                 )
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     await asyncio.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise timeout_error from exc
             except httpx.TransportError as exc:
-                last_exc = TransportError(str(exc))
-                if attempt < self._max_retries:
+                if not payment_attempted and attempt < self._max_retries:
                     await asyncio.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
-                raise last_exc from exc
+                raise TransportError(str(exc)) from exc
 
             if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
@@ -371,8 +402,8 @@ class AsyncTransport:
                         402,
                         {"error": {"code": "invalid_402", "message": resp.text}},
                     ) from exc
-                accepts = body.get("accepts") or []
-                if not accepts:
+                accepts = body.get("accepts") if isinstance(body, dict) else None
+                if not isinstance(accepts, list) or not accepts or not all(isinstance(item, dict) for item in accepts):
                     raise _map_error(
                         402,
                         {"error": {"code": "invalid_402", "message": "No payment requirements"}},
@@ -390,14 +421,13 @@ class AsyncTransport:
                 except Exception:
                     body = {"error": {"code": "unknown", "message": resp.text}}
 
-                if _should_retry(resp.status_code) and attempt < self._max_retries:
+                if not payment_attempted and _should_retry(resp.status_code) and attempt < self._max_retries:
                     await asyncio.sleep(_backoff_delay(attempt))
+                    attempt += 1
                     continue
                 raise _map_error(resp.status_code, body)
 
             return resp.json()
-
-        raise last_exc or TransportError("Request failed after retries")
 
     async def request_stream(
         self,
@@ -416,30 +446,64 @@ class AsyncTransport:
             "accept": "text/event-stream",
             **(extra_headers or {}),
         }
+        extra_auth_headers: dict[str, str] = {}
+        payment_attempted = False
 
-        async with self._client.stream(
-            method,
-            url,
-            json=json,
-            headers=headers,
-            timeout=timeout or self._timeout,
-        ) as resp:
-            if resp.status_code >= 400:
-                body_bytes = await resp.aread()
-                try:
-                    import json as _json
+        while True:
+            async with self._client.stream(
+                method,
+                url,
+                json=json,
+                headers={**headers, **extra_auth_headers},
+                timeout=timeout or self._timeout,
+            ) as resp:
+                if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
+                    body_bytes = await resp.aread()
+                    try:
+                        import json as _json
 
-                    body = _json.loads(body_bytes)
-                except Exception:
-                    body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
-                raise _map_error(resp.status_code, body)
+                        body = _json.loads(body_bytes)
+                    except Exception as exc:
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": body_bytes.decode(errors="replace")}},
+                        ) from exc
+                    accepts = body.get("accepts") if isinstance(body, dict) else None
+                    if (
+                        not isinstance(accepts, list)
+                        or not accepts
+                        or not all(isinstance(item, dict) for item in accepts)
+                    ):
+                        raise _map_error(
+                            402,
+                            {"error": {"code": "invalid_402", "message": "No payment requirements"}},
+                        )
+                    handler_result = self._payment_handler(
+                        {"url": url, "method": method, "body": json, "accepts": accepts}
+                    )
+                    if inspect.isawaitable(handler_result):
+                        handler_result = await handler_result
+                    extra_auth_headers.update(handler_result.get("headers", {}))
+                    payment_attempted = True
+                    continue
 
-            async for line in resp.aiter_lines():
-                if line.startswith("data: "):
-                    data = line[6:]
-                    if data == "[DONE]":
-                        return
-                    yield data
+                if resp.status_code >= 400:
+                    body_bytes = await resp.aread()
+                    try:
+                        import json as _json
+
+                        body = _json.loads(body_bytes)
+                    except Exception:
+                        body = {"error": {"code": "unknown", "message": body_bytes.decode(errors="replace")}}
+                    raise _map_error(resp.status_code, body)
+
+                async for line in resp.aiter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:]
+                        if data == "[DONE]":
+                            return
+                        yield data
+                return
 
     async def upload(
         self,

--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -1,6 +1,7 @@
 """Tests for AceDataCloud Python SDK."""
 
 import json
+from unittest.mock import Mock
 
 import httpx
 import pytest
@@ -8,6 +9,7 @@ import respx
 
 from acedatacloud import AceDataCloud, AsyncAceDataCloud
 from acedatacloud._runtime.errors import (
+    APIError,
     AuthenticationError,
     InsufficientBalanceError,
     RateLimitError,
@@ -17,14 +19,135 @@ from acedatacloud._runtime.errors import (
 
 @pytest.fixture
 def client():
-    c = AceDataCloud(api_token="test-token", max_retries=0)
+    c = AceDataCloud(api_token="test-token", base_url="https://api.acedata.cloud", max_retries=0)
     yield c
     c.close()
 
 
 @pytest.fixture
 def async_client():
-    return AsyncAceDataCloud(api_token="test-token", max_retries=0)
+    return AsyncAceDataCloud(api_token="test-token", base_url="https://api.acedata.cloud", max_retries=0)
+
+
+@respx.mock
+def test_default_api_base_uses_x402_host():
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        return_value=httpx.Response(200, json={"choices": []})
+    )
+    client = AceDataCloud(api_token="test-token", max_retries=0)
+
+    client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.called
+    client.close()
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_default_api_base_uses_x402_host():
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        return_value=httpx.Response(200, json={"choices": []})
+    )
+    client = AsyncAceDataCloud(api_token="test-token", max_retries=0)
+
+    await client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.called
+    await client.close()
+
+
+@respx.mock
+def test_x402_payment_retry_does_not_use_retry_budget():
+    payment_handler = Mock(return_value={"headers": {"X-Payment": "signed-payment"}})
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(200, json={"choices": []}),
+        ]
+    )
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.call_count == 2
+    assert route.calls.last.request.headers["X-Payment"] == "signed-payment"
+    client.close()
+
+
+@respx.mock
+def test_x402_paid_request_is_not_retried_with_same_signature():
+    payment_handler = Mock(return_value={"headers": {"X-Payment": "signed-payment"}})
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(500, json={"error": {"message": "upstream failed"}}),
+            httpx.Response(200, json={"choices": []}),
+        ]
+    )
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=2)
+
+    with pytest.raises(APIError, match="upstream failed"):
+        client.openai.chat.completions.create(model="test", messages=[])
+
+    assert route.call_count == 2
+    client.close()
+
+
+@pytest.mark.parametrize("body", [None, [], "error", {"accepts": "base"}, {"accepts": [None]}])
+@respx.mock
+def test_x402_rejects_malformed_payment_requirement_shapes(body):
+    payment_handler = Mock(return_value={"headers": {"X-Payment": "signed-payment"}})
+    respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(return_value=httpx.Response(402, json=body))
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    with pytest.raises(APIError) as exc_info:
+        client.openai.chat.completions.create(model="test", messages=[])
+
+    assert exc_info.value.code == "invalid_402"
+    payment_handler.assert_not_called()
+    client.close()
+
+
+@respx.mock
+def test_x402_payment_handler_supports_streaming():
+    payment_handler = Mock(return_value={"headers": {"X-Payment": "signed-payment"}})
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(200, text='data: {"delta":"ok"}\n\ndata: [DONE]\n\n'),
+        ]
+    )
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    chunks = list(client.openai.chat.completions.create(model="test", messages=[], stream=True))
+
+    assert chunks == [{"delta": "ok"}]
+    assert route.call_count == 2
+    assert route.calls.last.request.headers["X-Payment"] == "signed-payment"
+    client.close()
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_async_x402_payment_handler_supports_streaming():
+    async def payment_handler(_context):
+        return {"headers": {"X-Payment": "signed-payment"}}
+
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(402, json={"accepts": [{"network": "base", "scheme": "exact"}]}),
+            httpx.Response(200, text='data: {"delta":"ok"}\n\ndata: [DONE]\n\n'),
+        ]
+    )
+    client = AsyncAceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    stream = await client.openai.chat.completions.create(model="test", messages=[], stream=True)
+    chunks = [chunk async for chunk in stream]
+
+    assert chunks == [{"delta": "ok"}]
+    assert route.call_count == 2
+    assert route.calls.last.request.headers["X-Payment"] == "signed-payment"
+    await client.close()
 
 
 # ── OpenAI Chat Completions ──────────────────────────────────────────

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -113,8 +113,8 @@ try {
 ```typescript
 const client = new AceDataCloud({
   apiToken: 'your-token',
-  baseUrl: 'https://api.acedata.cloud',
-  platformBaseUrl: 'https://platform.acedata.cloud',
+  baseURL: 'https://x402.acedata.cloud',
+  platformBaseURL: 'https://platform.acedata.cloud',
   timeout: 300000,    // ms
   maxRetries: 2,
 });

--- a/typescript/src/runtime/transport.ts
+++ b/typescript/src/runtime/transport.ts
@@ -68,6 +68,18 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isAbortError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError';
+}
+
+function timeoutError(error: unknown): TimeoutError {
+  return new TimeoutError({
+    message: `Request timed out${error instanceof Error && error.message ? `: ${error.message}` : ''}`,
+    statusCode: 0,
+    code: 'timeout',
+  });
+}
+
 export interface TransportOptions {
   apiToken?: string;
   baseURL?: string;
@@ -104,7 +116,7 @@ export class Transport {
         code: 'no_token',
       });
     }
-    this.baseURL = (opts.baseURL ?? 'https://api.acedata.cloud').replace(/\/+$/, '');
+    this.baseURL = (opts.baseURL ?? 'https://x402.acedata.cloud').replace(/\/+$/, '');
     this.platformBaseURL = (opts.platformBaseURL ?? 'https://platform.acedata.cloud').replace(/\/+$/, '');
     this.timeout = opts.timeout ?? 300_000;
     this.maxRetries = opts.maxRetries ?? 2;
@@ -144,7 +156,8 @@ export class Transport {
     let lastError: Error | null = null;
     let paymentAttempted = false;
     let extraHeaders: Record<string, string> = {};
-    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+    let attempt = 0;
+    while (true) {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), timeoutMs);
       try {
@@ -158,20 +171,29 @@ export class Transport {
 
         if (resp.status === 402 && this.paymentHandler && !paymentAttempted) {
           const text = await resp.text();
-          let body: PaymentRequiredBody;
+          let body: unknown;
           try {
-            body = JSON.parse(text) as PaymentRequiredBody;
+            body = JSON.parse(text);
           } catch {
             throw mapError(402, { error: { code: 'invalid_402', message: text } });
           }
-          if (!body.accepts?.length) {
+          if (
+            !body ||
+            typeof body !== 'object' ||
+            !Array.isArray((body as PaymentRequiredBody).accepts) ||
+            !(body as PaymentRequiredBody).accepts.length ||
+            !(body as PaymentRequiredBody).accepts.every(
+              (requirement) => requirement !== null && typeof requirement === 'object'
+            )
+          ) {
             throw mapError(402, { error: { code: 'invalid_402', message: 'No payment requirements' } });
           }
+          const paymentRequired = body as PaymentRequiredBody;
           const result = await this.paymentHandler({
             url,
             method,
             body: opts.json,
-            accepts: body.accepts,
+            accepts: paymentRequired.accepts,
           });
           extraHeaders = { ...extraHeaders, ...result.headers };
           paymentAttempted = true;
@@ -186,8 +208,9 @@ export class Transport {
           } catch {
             body = { error: { code: 'unknown', message: text } };
           }
-          if (RETRY_STATUS_CODES.has(resp.status) && attempt < this.maxRetries) {
+          if (!paymentAttempted && RETRY_STATUS_CODES.has(resp.status) && attempt < this.maxRetries) {
             await sleep(backoffDelay(attempt) * 1000);
+            attempt += 1;
             continue;
           }
           throw mapError(resp.status, body);
@@ -197,14 +220,19 @@ export class Transport {
       } catch (err) {
         clearTimeout(timer);
         if (err instanceof APIError) throw err;
-        lastError = err as Error;
-        if (attempt < this.maxRetries) {
+        if (isAbortError(err)) {
+          lastError = timeoutError(err);
+        } else {
+          lastError = err as Error;
+        }
+        if (!paymentAttempted && attempt < this.maxRetries) {
           await sleep(backoffDelay(attempt) * 1000);
+          attempt += 1;
           continue;
         }
+        throw lastError;
       }
     }
-    throw lastError ?? new TransportError('Request failed after retries');
   }
 
   async *requestStream(
@@ -214,52 +242,115 @@ export class Transport {
   ): AsyncGenerator<string, void, unknown> {
     const url = `${this.baseURL}${path}`;
     const headers = { ...this.headers, accept: 'text/event-stream' };
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), opts.timeout ?? this.timeout);
+    let paymentAttempted = false;
+    let extraHeaders: Record<string, string> = {};
 
-    try {
-      const resp = await fetch(url, {
-        method,
-        headers,
-        body: opts.json ? JSON.stringify(opts.json) : undefined,
-        signal: controller.signal,
-      });
-
-      if (resp.status >= 400) {
-        const text = await resp.text();
-        let body: Record<string, unknown>;
+    while (true) {
+      const controller = new AbortController();
+      const timeoutMs = opts.timeout ?? this.timeout;
+      const connectionTimer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        let resp: Response;
         try {
-          body = JSON.parse(text) as Record<string, unknown>;
-        } catch {
-          body = { error: { code: 'unknown', message: text } };
+          resp = await fetch(url, {
+            method,
+            headers: { ...headers, ...extraHeaders },
+            body: opts.json ? JSON.stringify(opts.json) : undefined,
+            signal: controller.signal,
+          });
+        } catch (error) {
+          if (isAbortError(error)) throw timeoutError(error);
+          throw error;
+        } finally {
+          clearTimeout(connectionTimer);
         }
-        throw mapError(resp.status, body);
-      }
 
-      if (!resp.body) throw new TransportError('No response body for stream');
+        if (resp.status === 402 && this.paymentHandler && !paymentAttempted) {
+          const text = await resp.text();
+          let body: unknown;
+          try {
+            body = JSON.parse(text);
+          } catch {
+            throw mapError(402, { error: { code: 'invalid_402', message: text } });
+          }
+          if (
+            !body ||
+            typeof body !== 'object' ||
+            !Array.isArray((body as PaymentRequiredBody).accepts) ||
+            !(body as PaymentRequiredBody).accepts.length ||
+            !(body as PaymentRequiredBody).accepts.every(
+              (requirement) => requirement !== null && typeof requirement === 'object'
+            )
+          ) {
+            throw mapError(402, { error: { code: 'invalid_402', message: 'No payment requirements' } });
+          }
+          const paymentRequired = body as PaymentRequiredBody;
+          const result = await this.paymentHandler({
+            url,
+            method,
+            body: opts.json,
+            accepts: paymentRequired.accepts,
+          });
+          extraHeaders = { ...extraHeaders, ...result.headers };
+          paymentAttempted = true;
+          continue;
+        }
 
-      const reader = resp.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
+        if (resp.status >= 400) {
+          const text = await resp.text();
+          let body: Record<string, unknown>;
+          try {
+            body = JSON.parse(text) as Record<string, unknown>;
+          } catch {
+            body = { error: { code: 'unknown', message: text } };
+          }
+          throw mapError(resp.status, body);
+        }
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
+        if (!resp.body) throw new TransportError('No response body for stream');
 
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
 
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            const data = line.slice(6);
-            if (data === '[DONE]') return;
-            yield data;
+        try {
+          while (true) {
+            const idleTimer = setTimeout(() => controller.abort(), timeoutMs);
+            let result: Awaited<ReturnType<typeof reader.read>>;
+            try {
+              result = await reader.read();
+            } catch (error) {
+              if (isAbortError(error)) throw timeoutError(error);
+              throw error;
+            } finally {
+              clearTimeout(idleTimer);
+            }
+            const { done, value } = result;
+            if (done) break;
+            buffer += decoder.decode(value, { stream: true });
+
+            const lines = buffer.split('\n');
+            buffer = lines.pop() ?? '';
+
+            for (const line of lines) {
+              if (line.startsWith('data: ')) {
+                const data = line.slice(6);
+                if (data === '[DONE]') return;
+                yield data;
+              }
+            }
+          }
+        } finally {
+          try {
+            await reader.cancel();
+          } catch {
+            // Preserve the original stream error, especially SDK TimeoutError.
           }
         }
+        return;
+      } finally {
+        clearTimeout(connectionTimer);
       }
-    } finally {
-      clearTimeout(timer);
     }
   }
 
@@ -288,12 +379,18 @@ export class Transport {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), opts.timeout ?? this.timeout);
     try {
-      const resp = await fetch(url, {
-        method: 'POST',
-        headers: authHeaders,
-        body,
-        signal: controller.signal,
-      });
+      let resp: Response;
+      try {
+        resp = await fetch(url, {
+          method: 'POST',
+          headers: authHeaders,
+          body,
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (isAbortError(error)) throw timeoutError(error);
+        throw error;
+      }
       clearTimeout(timer);
 
       if (resp.status >= 400) {

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for AceDataCloud TypeScript SDK.
  *
  * These tests run against the live API. Set these in .env (repo root) or environment:
- *   - ACEDATACLOUD_API_TOKEN      — API token for api.acedata.cloud
+ *   - ACEDATACLOUD_API_TOKEN      — API token for x402.acedata.cloud
  *   - ACEDATACLOUD_PLATFORM_TOKEN — Platform token for platform.acedata.cloud (optional)
  *
  * Usage:

--- a/typescript/tests/transport.test.ts
+++ b/typescript/tests/transport.test.ts
@@ -1,0 +1,225 @@
+import { Transport } from '../src/runtime/transport';
+import { TimeoutError } from '../src/runtime/errors';
+
+describe('Transport API base URL', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses the dedicated X402 host by default', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const transport = new Transport({ apiToken: 'test-token', maxRetries: 0 });
+
+    await transport.request('POST', '/openai/chat/completions', { json: { model: 'test' } });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://x402.acedata.cloud/openai/chat/completions',
+      expect.any(Object)
+    );
+  });
+
+  it('preserves an explicit API base URL override', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+    const transport = new Transport({
+      apiToken: 'test-token',
+      baseURL: 'https://api.acedata.cloud/',
+      maxRetries: 0,
+    });
+
+    await transport.request('GET', '/openai/models');
+
+    expect(fetchMock).toHaveBeenCalledWith('https://api.acedata.cloud/openai/models', expect.any(Object));
+  });
+
+  it('maps aborted requests to the SDK TimeoutError', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const transport = new Transport({ apiToken: 'test-token', maxRetries: 0 });
+
+    await expect(transport.request('GET', '/openai/models')).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it('retries once with payment headers when maxRetries is zero', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const transport = new Transport({ paymentHandler, maxRetries: 0 });
+
+    await transport.request('POST', '/openai/chat/completions', { json: { model: 'test' } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({ 'X-Payment': 'signed-payment' });
+  });
+
+  it('does not retry a paid request with the same signature', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'upstream failed' } }), { status: 500 })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const transport = new Transport({ paymentHandler, maxRetries: 2 });
+
+    await expect(
+      transport.request('POST', '/openai/chat/completions', { json: { model: 'test' } })
+    ).rejects.toThrow('upstream failed');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([null, [], 'error', { accepts: 'base' }, { accepts: [null] }])(
+    'rejects malformed payment requirements: %p',
+    async (body) => {
+      const paymentHandler = jest.fn();
+      jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify(body), { status: 402 })
+      );
+      const transport = new Transport({ paymentHandler, maxRetries: 0 });
+
+      await expect(
+        transport.request('POST', '/openai/chat/completions', { json: { model: 'test' } })
+      ).rejects.toMatchObject({ code: 'invalid_402' });
+
+      expect(paymentHandler).not.toHaveBeenCalled();
+    }
+  );
+
+  it('retries streaming requests with payment headers', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(
+        new Response('data: {"delta":"ok"}\n\ndata: [DONE]\n\n', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        })
+      );
+    const transport = new Transport({ paymentHandler, maxRetries: 0 });
+
+    const chunks: string[] = [];
+    for await (const chunk of transport.requestStream('POST', '/openai/chat/completions', {
+      json: { model: 'test', stream: true },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['{"delta":"ok"}']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({ 'X-Payment': 'signed-payment' });
+    expect(fetchMock.mock.calls[1][1]?.signal).not.toBe(fetchMock.mock.calls[0][1]?.signal);
+  });
+
+  it('cancels a paid stream when the consumer exits early', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'X-Payment': 'signed-payment' },
+    });
+    const cancel = jest.fn();
+    const streamBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: {"delta":"ok"}\n\n'));
+      },
+      cancel,
+    });
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ accepts: [{ network: 'base', scheme: 'exact' }] }), { status: 402 })
+      )
+      .mockResolvedValueOnce(new Response(streamBody, { status: 200 }));
+    const transport = new Transport({ paymentHandler, maxRetries: 0 });
+
+    for await (const _chunk of transport.requestStream('POST', '/openai/chat/completions', {
+      json: { model: 'test', stream: true },
+    })) {
+      break;
+    }
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the idle timeout after each stream chunk', async () => {
+    const encoder = new TextEncoder();
+    const streamBody = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        controller.enqueue(encoder.encode('data: {"delta":"one"}\n\n'));
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        controller.enqueue(encoder.encode('data: {"delta":"two"}\n\ndata: [DONE]\n\n'));
+        controller.close();
+      },
+    });
+    jest.spyOn(global, 'fetch').mockResolvedValue(new Response(streamBody, { status: 200 }));
+    const transport = new Transport({ apiToken: 'test-token', maxRetries: 0 });
+
+    const chunks: string[] = [];
+    for await (const chunk of transport.requestStream('POST', '/openai/chat/completions', {
+      json: { model: 'test', stream: true },
+      timeout: 8,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['{"delta":"one"}', '{"delta":"two"}']);
+  });
+
+  it('preserves TimeoutError when stream cancellation also fails', async () => {
+    jest.useFakeTimers();
+    const cancel = jest.fn().mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const reader = {
+      read: jest.fn().mockImplementation(
+        () => new Promise((_, reject) => setTimeout(() => reject(new DOMException('aborted', 'AbortError')), 10))
+      ),
+      cancel,
+    };
+    const body = { getReader: () => reader } as unknown as ReadableStream<Uint8Array>;
+    jest.spyOn(global, 'fetch').mockResolvedValue({ status: 200, body } as Response);
+    const transport = new Transport({ apiToken: 'test-token', maxRetries: 0 });
+
+    const result = (async () => {
+      for await (const _chunk of transport.requestStream('GET', '/stream', { timeout: 5 })) {
+        // No chunks expected.
+      }
+    })();
+    const assertion = expect(result).rejects.toBeInstanceOf(TimeoutError);
+    await jest.advanceTimersByTimeAsync(10);
+
+    await assertion;
+    expect(cancel).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('maps aborted uploads to the SDK TimeoutError', async () => {
+    jest.spyOn(global, 'fetch').mockRejectedValue(new DOMException('aborted', 'AbortError'));
+    const transport = new Transport({ apiToken: 'test-token', maxRetries: 0 });
+
+    await expect(transport.upload('/api/v1/files/', new Uint8Array([1]), 'test.txt')).rejects.toBeInstanceOf(
+      TimeoutError
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- default Python and TypeScript API clients to `https://x402.acedata.cloud`; keep the platform management plane unchanged
- preserve explicit `base_url` / `baseURL` overrides for Bearer users that still need `api.acedata.cloud`
- make the one X402 paid retry independent of transient retry budgets, including `max_retries=0`
- add sync/async streaming payment negotiation without reusing signed payment headers
- normalize TypeScript request/upload/stream timeouts to SDK `TimeoutError`, use per-read SSE idle timeouts, and cancel early-closed streams safely
- reject malformed 402 requirement containers and entries before invoking signers
- document the published `acedatacloud-x402` Python signer and correct TypeScript option names

Go is intentionally unchanged because X402Client currently integrates only with the Python and TypeScript SDKs.

## Validation

- Python: `55 passed, 29 skipped`; Ruff passed
- TypeScript: `33 passed, 27 skipped`; typecheck and package build passed
- prior live validation: default non-streaming call returned `DEFAULT_OK`; default streaming call with `max_retries=0` returned `STREAM_OK`

## Rollout dependency

Merge and publish this SDK before removing X402 from `api.acedata.cloud`. Verify the public PyPI/npm artifacts default to `https://x402.acedata.cloud`; local source is not sufficient.

## Adversarial Review

Independent review found and the change fixes:

- paid retry consumed `maxRetries=0`
- sync/async streaming bypassed payment handlers
- transient retries reused signed payment headers
- streaming shared one negotiation/lifetime timeout
- early stream exits leaked paid readers
- native AbortError escaped instead of SDK TimeoutError
- cleanup cancellation could mask TimeoutError
- upload AbortError was not normalized
- malformed `accepts` entries reached signers
- Python docs incorrectly claimed no ready-made signer existed

All findings have focused executable coverage. The final incremental reviewer invocation returned no response; this is recorded rather than treated as a clean verdict.
