### PR TITLE
Fix completed async task detection

### DIFF
--- a/python/src/acedatacloud/_runtime/tasks.py
+++ b/python/src/acedatacloud/_runtime/tasks.py
@@ -7,6 +7,27 @@ import time
 from typing import Any
 
 
+def _task_status(state: dict[str, Any]) -> str:
+    response = state.get("response")
+    if response is None:
+        response = state
+    if not isinstance(response, dict):
+        return ""
+    status = response.get("status")
+    if status in ("succeeded", "failed"):
+        return status
+    if status is not None:
+        return ""
+    finished = response.get("finished_at") is not None or state.get("finished_at") is not None
+    if not finished:
+        return ""
+    if response.get("success") is True:
+        return "succeeded"
+    if response.get("success") is False:
+        return "failed"
+    return ""
+
+
 class TaskHandle:
     """Synchronous task handle for polling long-running operations."""
 
@@ -26,9 +47,7 @@ class TaskHandle:
 
     def is_completed(self) -> bool:
         state = self.get()
-        response = state.get("response", state)
-        status = response.get("status", "")
-        return status in ("succeeded", "failed")
+        return _task_status(state) in ("succeeded", "failed")
 
     def wait(
         self,
@@ -40,12 +59,8 @@ class TaskHandle:
         start = time.monotonic()
         while time.monotonic() - start < max_wait:
             state = self.get()
-            response = state.get("response", state)
-            status = response.get("status", "")
-            if status == "succeeded":
-                self._result = state
-                return state
-            if status == "failed":
+            status = _task_status(state)
+            if status in ("succeeded", "failed"):
                 self._result = state
                 return state
             time.sleep(poll_interval)
@@ -73,9 +88,7 @@ class AsyncTaskHandle:
 
     async def is_completed(self) -> bool:
         state = await self.get()
-        response = state.get("response", state)
-        status = response.get("status", "")
-        return status in ("succeeded", "failed")
+        return _task_status(state) in ("succeeded", "failed")
 
     async def wait(
         self,
@@ -86,12 +99,8 @@ class AsyncTaskHandle:
         start = time.monotonic()
         while time.monotonic() - start < max_wait:
             state = await self.get()
-            response = state.get("response", state)
-            status = response.get("status", "")
-            if status == "succeeded":
-                self._result = state
-                return state
-            if status == "failed":
+            status = _task_status(state)
+            if status in ("succeeded", "failed"):
                 self._result = state
                 return state
             await asyncio.sleep(poll_interval)

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -1,0 +1,87 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from acedatacloud._runtime.tasks import AsyncTaskHandle, TaskHandle
+
+
+def test_wait_accepts_success_data_without_status():
+    pending = {"response": {"success": True, "task_id": "task-1"}}
+    completed = {
+        "finished_at": "2026-07-18T08:16:11Z",
+        "response": {
+            "success": True,
+            "task_id": "task-1",
+            "data": [{"image_url": "https://cdn.example/image.png"}],
+        },
+    }
+    transport = Mock()
+    transport.request.side_effect = [pending, completed]
+    handle = TaskHandle("task-1", "/nano-banana/tasks", transport)
+
+    result = handle.wait(poll_interval=0, max_wait=1)
+
+    assert result == completed
+    assert transport.request.call_count == 2
+
+
+def test_is_completed_accepts_explicit_status():
+    transport = Mock()
+    transport.request.return_value = {"response": {"status": "succeeded"}}
+
+    assert TaskHandle("task-1", "/tasks", transport).is_completed() is True
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        {"response": {"success": True, "data": []}},
+        {"response": {"success": True, "data": None}},
+        {"response": {"success": False, "error": "temporary"}},
+        {"response": {"success": False, "error": None}},
+        {"response": None},
+        {"finished_at": "2026-07-18T08:16:11Z", "response": {"status": "processing", "success": True}},
+    ],
+)
+def test_is_completed_waits_without_terminal_status_or_finished_at(state):
+    transport = Mock()
+    transport.request.return_value = state
+
+    assert TaskHandle("task-1", "/tasks", transport).is_completed() is False
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        ({"finished_at": "2026-07-18T08:16:11Z", "response": {"success": True, "data": None}}, True),
+        ({"response": {"finished_at": "2026-07-18T08:16:11Z", "success": False}}, True),
+        ({"finished_at": "2026-07-18T08:16:11Z", "response": {"success": None}}, False),
+        ({"finished_at": "2026-07-18T08:16:11Z", "response": {"status": "succeeded", "success": False}}, True),
+        ({"response": None, "status": "succeeded"}, True),
+    ],
+)
+def test_is_completed_handles_statusless_terminal_shapes(state, expected):
+    transport = Mock()
+    transport.request.return_value = state
+
+    assert TaskHandle("task-1", "/tasks", transport).is_completed() is expected
+
+
+@pytest.mark.asyncio
+async def test_async_wait_accepts_success_data_without_status():
+    pending = {"response": {"success": True, "task_id": "task-1"}}
+    completed = {
+        "finished_at": "2026-07-18T08:16:11Z",
+        "response": {
+            "success": True,
+            "data": [{"image_url": "https://cdn.example/image.png"}],
+        },
+    }
+    transport = AsyncMock()
+    transport.request.side_effect = [pending, completed]
+    handle = AsyncTaskHandle("task-1", "/nano-banana/tasks", transport)
+
+    result = await handle.wait(poll_interval=0, max_wait=1)
+
+    assert result == completed
+    assert transport.request.await_count == 2

--- a/typescript/src/runtime/tasks.ts
+++ b/typescript/src/runtime/tasks.ts
@@ -7,6 +7,19 @@ export interface TaskHandleOptions {
   maxWait?: number;
 }
 
+function taskStatus(state: Record<string, unknown>): 'succeeded' | 'failed' | '' {
+  const response = (state.response ?? state) as Record<string, unknown>;
+  if (response.status === 'succeeded' || response.status === 'failed') return response.status;
+  if (response.status !== undefined && response.status !== null) return '';
+  const finished =
+    (response.finished_at !== undefined && response.finished_at !== null) ||
+    (state.finished_at !== undefined && state.finished_at !== null);
+  if (!finished) return '';
+  if (response.success === true) return 'succeeded';
+  if (response.success === false) return 'failed';
+  return '';
+}
+
 export class TaskHandle {
   readonly id: string;
   private pollEndpoint: string;
@@ -27,8 +40,7 @@ export class TaskHandle {
 
   async isCompleted(): Promise<boolean> {
     const state = await this.get();
-    const response = (state.response ?? state) as Record<string, unknown>;
-    const status = response.status as string;
+    const status = taskStatus(state);
     return status === 'succeeded' || status === 'failed';
   }
 
@@ -39,8 +51,7 @@ export class TaskHandle {
 
     while (Date.now() - start < maxWait) {
       const state = await this.get();
-      const response = (state.response ?? state) as Record<string, unknown>;
-      const status = response.status as string;
+      const status = taskStatus(state);
 
       if (status === 'succeeded' || status === 'failed') {
         this._result = state;

--- a/typescript/tests/tasks.test.ts
+++ b/typescript/tests/tasks.test.ts
@@ -1,0 +1,57 @@
+import { TaskHandle } from '../src/runtime/tasks';
+
+describe('TaskHandle', () => {
+  it('waits through accepted responses and completes on success data without status', async () => {
+    const request = jest
+      .fn()
+      .mockResolvedValueOnce({ response: { success: true, task_id: 'task-1' } })
+      .mockResolvedValueOnce({
+        finished_at: '2026-07-18T08:16:11Z',
+        response: {
+          success: true,
+          task_id: 'task-1',
+          data: [{ image_url: 'https://cdn.example/image.png' }],
+        },
+      });
+    const handle = new TaskHandle('task-1', '/nano-banana/tasks', { request } as any);
+
+    const result = await handle.wait({ pollInterval: 0, maxWait: 1000 });
+
+    expect(result).toEqual(expect.objectContaining({ response: expect.objectContaining({ success: true }) }));
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it('recognizes explicit terminal status', async () => {
+    const request = jest.fn().mockResolvedValue({ response: { status: 'succeeded' } });
+    const handle = new TaskHandle('task-1', '/tasks', { request } as any);
+
+    await expect(handle.isCompleted()).resolves.toBe(true);
+  });
+
+  it.each([
+    { response: { success: true, data: [] } },
+    { response: { success: true, data: null } },
+    { response: { success: false, error: 'temporary' } },
+    { response: { success: false, error: null } },
+    { response: null },
+    { finished_at: '2026-07-18T08:16:11Z', response: { status: 'processing', success: true } },
+  ])('waits without terminal status or finished_at: %p', async (state) => {
+    const request = jest.fn().mockResolvedValue(state);
+    const handle = new TaskHandle('task-1', '/tasks', { request } as any);
+
+    await expect(handle.isCompleted()).resolves.toBe(false);
+  });
+
+  it.each([
+    [{ finished_at: '2026-07-18T08:16:11Z', response: { success: true, data: null } }, true],
+    [{ response: { finished_at: '2026-07-18T08:16:11Z', success: false } }, true],
+    [{ finished_at: '2026-07-18T08:16:11Z', response: { success: null } }, false],
+    [{ finished_at: '2026-07-18T08:16:11Z', response: { status: 'succeeded', success: false } }, true],
+    [{ response: null, status: 'succeeded' }, true],
+  ])('handles terminal shape %p', async (state, expected) => {
+    const request = jest.fn().mockResolvedValue(state);
+    const handle = new TaskHandle('task-1', '/tasks', { request } as any);
+
+    await expect(handle.isCompleted()).resolves.toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

- recognize completed async tasks that expose top-level `finished_at` and nested `response.success` without `response.status`
- keep explicit terminal and non-terminal statuses authoritative
- align Python and TypeScript null/status semantics with regression coverage

## Validation

- Python: 69 passed, 29 skipped; Ruff passed
- TypeScript: 46 passed, 27 skipped; typecheck and build passed

## 🤖 对抗评审 (reviewer: codex, 1 round)

- VERDICT: CLEAN
