### PR TITLE
feat: support official x402 v2 HTTP headers

### DIFF
--- a/go/client_test.go
+++ b/go/client_test.go
@@ -2,6 +2,7 @@ package acedatacloud
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -185,6 +186,86 @@ func TestPaymentHandler_OnSecond402ThenSuccess(t *testing.T) {
 	}
 	if hit != 2 {
 		t.Fatalf("expected 2 hits, got %d", hit)
+	}
+}
+
+func TestPaymentHandler_ParsesPaymentRequiredHeader(t *testing.T) {
+	var calls int
+	required := `{"x402Version":2,"accepts":[{"network":"eip155:8453","scheme":"exact","amount":"1"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("PAYMENT-REQUIRED", base64.StdEncoding.EncodeToString([]byte(required)))
+			w.WriteHeader(http.StatusPaymentRequired)
+			_, _ = w.Write([]byte(`{"error":"payment required"}`))
+			return
+		}
+		if got := r.Header.Get("PAYMENT-SIGNATURE"); got != "signed-payment" {
+			t.Fatalf("expected PAYMENT-SIGNATURE, got %q", got)
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	handler := PaymentHandlerFunc(func(_ context.Context, pctx PaymentContext) (PaymentResult, error) {
+		if got := pctx.Accepts[0]["network"]; got != "eip155:8453" {
+			t.Fatalf("expected canonical network, got %v", got)
+		}
+		return PaymentResult{Headers: map[string]string{"PAYMENT-SIGNATURE": "signed-payment"}}, nil
+	})
+	c, _ := NewClient(WithBaseURL(srv.URL), WithPaymentHandler(handler))
+
+	if _, err := c.transport.do(
+		context.Background(),
+		requestOpts{Method: http.MethodGet, Path: "/paid"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected two calls, got %d", calls)
+	}
+}
+
+func TestPaymentHandler_ParsesPaymentRequiredHeaderForStream(t *testing.T) {
+	var calls int
+	required := `{"x402Version":2,"accepts":[{"network":"eip155:8453","scheme":"exact","amount":"1"}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("PAYMENT-REQUIRED", base64.StdEncoding.EncodeToString([]byte(required)))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+		if got := r.Header.Get("PAYMENT-SIGNATURE"); got != "signed-payment" {
+			t.Fatalf("expected PAYMENT-SIGNATURE, got %q", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chunk-1\"}\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	handler := PaymentHandlerFunc(func(_ context.Context, pctx PaymentContext) (PaymentResult, error) {
+		if got := pctx.Accepts[0]["network"]; got != "eip155:8453" {
+			t.Fatalf("expected canonical network, got %v", got)
+		}
+		return PaymentResult{Headers: map[string]string{"PAYMENT-SIGNATURE": "signed-payment"}}, nil
+	})
+	c, _ := NewClient(WithBaseURL(srv.URL), WithPaymentHandler(handler))
+
+	chunks, errors := c.OpenAI().Chat().Completions().CreateStream(context.Background(), ChatCompletionRequest{
+		Model: "test", Messages: []map[string]any{{"role": "user", "content": "hi"}},
+	})
+	var received []map[string]any
+	for chunk := range chunks {
+		received = append(received, chunk)
+	}
+	for err := range errors {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if calls != 2 || len(received) != 1 || received[0]["id"] != "chunk-1" {
+		t.Fatalf("unexpected stream result calls=%d chunks=%+v", calls, received)
 	}
 }
 

--- a/go/payment.go
+++ b/go/payment.go
@@ -6,7 +6,7 @@ import "context"
 //
 // Using map[string]any keeps the SDK free of chain-specific types — the
 // companion x402-client package is responsible for interpreting the
-// ``extra`` field and producing an ``X-Payment`` envelope.
+// ``extra`` field and producing a ``PAYMENT-SIGNATURE`` envelope.
 type PaymentRequirement = map[string]any
 
 // PaymentContext is passed to a PaymentHandler when the transport
@@ -19,14 +19,14 @@ type PaymentContext struct {
 }
 
 // PaymentResult is what a PaymentHandler must return: the headers to
-// attach to the retried request (typically ``X-Payment``).
+// attach to the retried request (typically ``PAYMENT-SIGNATURE``).
 type PaymentResult struct {
 	Headers map[string]string
 }
 
 // PaymentHandler is the hook the SDK calls on 402. Implementations
 // typically sign an EIP-3009 authorization (EVM) or submit a
-// TransferChecked transaction (Solana) and return an ``X-Payment``
+// TransferChecked transaction (Solana) and return a ``PAYMENT-SIGNATURE``
 // header.
 type PaymentHandler interface {
 	Handle(ctx context.Context, pctx PaymentContext) (PaymentResult, error)

--- a/go/transport.go
+++ b/go/transport.go
@@ -3,6 +3,7 @@ package acedatacloud
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,6 +25,32 @@ type transport struct {
 }
 
 var retryStatus = map[int]bool{408: true, 409: true, 429: true, 500: true, 502: true, 503: true, 504: true}
+
+func parsePaymentRequired(resp *http.Response, body []byte) ([]PaymentRequirement, error) {
+	paymentRequired := body
+	if encoded := resp.Header.Get("PAYMENT-REQUIRED"); encoded != "" {
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, mapError(402, map[string]any{"error": map[string]any{"code": "invalid_402", "message": "Invalid PAYMENT-REQUIRED header"}})
+		}
+		paymentRequired = decoded
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(paymentRequired, &parsed); err != nil {
+		return nil, mapError(402, map[string]any{"error": map[string]any{"code": "invalid_402", "message": string(paymentRequired)}})
+	}
+	rawAccepts, _ := parsed["accepts"].([]any)
+	accepts := make([]PaymentRequirement, 0, len(rawAccepts))
+	for _, value := range rawAccepts {
+		if requirement, ok := value.(map[string]any); ok {
+			accepts = append(accepts, requirement)
+		}
+	}
+	if len(accepts) == 0 || len(accepts) != len(rawAccepts) {
+		return nil, mapError(402, map[string]any{"error": map[string]any{"code": "invalid_402", "message": "No payment requirements"}})
+	}
+	return accepts, nil
+}
 
 func newTransport(opts *options) (*transport, error) {
 	token := opts.apiToken
@@ -131,19 +158,9 @@ func (t *transport) do(ctx context.Context, r requestOpts) (map[string]any, erro
 
 		// Handle 402 Payment Required: invoke handler once, then retry with new headers.
 		if resp.StatusCode == http.StatusPaymentRequired && t.opts.paymentHandler != nil && !paymentAttempted {
-			var parsed map[string]any
-			if err := json.Unmarshal(respBody, &parsed); err != nil {
-				return nil, mapError(402, map[string]any{"error": map[string]any{"code": "invalid_402", "message": string(respBody)}})
-			}
-			rawAccepts, _ := parsed["accepts"].([]any)
-			if len(rawAccepts) == 0 {
-				return nil, mapError(402, map[string]any{"error": map[string]any{"code": "invalid_402", "message": "No payment requirements"}})
-			}
-			accepts := make([]PaymentRequirement, 0, len(rawAccepts))
-			for _, a := range rawAccepts {
-				if m, ok := a.(map[string]any); ok {
-					accepts = append(accepts, m)
-				}
+			accepts, err := parsePaymentRequired(resp, respBody)
+			if err != nil {
+				return nil, err
 			}
 			pctx := PaymentContext{URL: fullURL, Method: r.Method, Body: r.Body, Accepts: accepts}
 			result, err := t.opts.paymentHandler.Handle(ctx, pctx)
@@ -206,20 +223,53 @@ func (t *transport) stream(ctx context.Context, path string, body any) (<-chan [
 			}
 		}
 
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(bodyBytes))
-		if err != nil {
-			errCh <- err
-			return
-		}
-		for k, v := range t.headers {
-			req.Header.Set(k, v)
-		}
-		req.Header.Set("Accept", "text/event-stream")
+		extraAuth := map[string]string{}
+		paymentAttempted := false
+		var resp *http.Response
+		for {
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(bodyBytes))
+			if err != nil {
+				errCh <- err
+				return
+			}
+			for k, v := range t.headers {
+				req.Header.Set(k, v)
+			}
+			for k, v := range extraAuth {
+				req.Header.Set(k, v)
+			}
+			req.Header.Set("Accept", "text/event-stream")
 
-		resp, err := t.httpClient.Do(req)
-		if err != nil {
-			errCh <- err
-			return
+			resp, err = t.httpClient.Do(req)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if resp.StatusCode != http.StatusPaymentRequired || t.opts.paymentHandler == nil || paymentAttempted {
+				break
+			}
+			respBody, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				errCh <- readErr
+				return
+			}
+			accepts, parseErr := parsePaymentRequired(resp, respBody)
+			if parseErr != nil {
+				errCh <- parseErr
+				return
+			}
+			result, handleErr := t.opts.paymentHandler.Handle(ctx, PaymentContext{
+				URL: fullURL, Method: http.MethodPost, Body: body, Accepts: accepts,
+			})
+			if handleErr != nil {
+				errCh <- fmt.Errorf("payment handler: %w", handleErr)
+				return
+			}
+			for k, v := range result.Headers {
+				extraAuth[k] = v
+			}
+			paymentAttempted = true
 		}
 		defer resp.Body.Close()
 

--- a/python/src/acedatacloud/_runtime/payment.py
+++ b/python/src/acedatacloud/_runtime/payment.py
@@ -2,20 +2,23 @@
 
 When the API returns ``402 Payment Required``, the transport calls the
 configured payment handler to obtain the extra headers (typically
-``X-Payment``) to attach to the retry. This keeps the SDK free of any
+``PAYMENT-SIGNATURE``) to attach to the retry. This keeps the SDK free of any
 chain-specific signing logic, and lets callers plug in an x402
 implementation when one becomes available.
 """
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
+import base64
+import json
+from collections.abc import Awaitable, Mapping
 from typing import Any, Callable, TypedDict, Union
 
 
 class PaymentRequirement(TypedDict, total=False):
     scheme: str
     network: str
+    amount: str
     maxAmountRequired: str
     maxTimeoutSeconds: int
     resource: str
@@ -45,3 +48,27 @@ class PaymentHandlerResult(TypedDict):
 SyncPaymentHandler = Callable[[PaymentHandlerContext], PaymentHandlerResult]
 AsyncPaymentHandler = Callable[[PaymentHandlerContext], Awaitable[PaymentHandlerResult]]
 PaymentHandler = Union[SyncPaymentHandler, AsyncPaymentHandler]
+
+
+def parse_payment_required(headers: Mapping[str, str], body: Any) -> dict[str, Any]:
+    encoded = headers.get("PAYMENT-REQUIRED") or headers.get("payment-required")
+    if encoded:
+        try:
+            value = json.loads(base64.b64decode(encoded).decode("utf-8"))
+        except Exception as exc:
+            raise ValueError("Invalid PAYMENT-REQUIRED header") from exc
+        if isinstance(value, dict):
+            return value
+        raise ValueError("Invalid PAYMENT-REQUIRED header")
+    if isinstance(body, dict):
+        return body
+    if isinstance(body, (bytes, bytearray)):
+        body = body.decode("utf-8", errors="replace")
+    if isinstance(body, str):
+        try:
+            value = json.loads(body)
+        except Exception:
+            return {}
+        if isinstance(value, dict):
+            return value
+    return {}

--- a/python/src/acedatacloud/_runtime/transport.py
+++ b/python/src/acedatacloud/_runtime/transport.py
@@ -26,6 +26,7 @@ from acedatacloud._runtime.errors import (
 from acedatacloud._runtime.payment import (
     PaymentHandler,
     SyncPaymentHandler,
+    parse_payment_required,
 )
 
 _ERROR_CODE_MAP = {
@@ -175,13 +176,10 @@ class SyncTransport:
 
             if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
-                    body = resp.json()
-                except Exception as exc:
-                    raise _map_error(
-                        402,
-                        {"error": {"code": "invalid_402", "message": resp.text}},
-                    ) from exc
-                accepts = body.get("accepts") if isinstance(body, dict) else None
+                    body = parse_payment_required(resp.headers, resp.text)
+                except ValueError as exc:
+                    raise _map_error(402, {"error": {"code": "invalid_402", "message": str(exc)}}) from exc
+                accepts = body.get("accepts")
                 if not isinstance(accepts, list) or not accepts or not all(isinstance(item, dict) for item in accepts):
                     raise _map_error(
                         402,
@@ -237,15 +235,10 @@ class SyncTransport:
                 if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                     body_bytes = resp.read()
                     try:
-                        import json as _json
-
-                        body = _json.loads(body_bytes)
-                    except Exception as exc:
-                        raise _map_error(
-                            402,
-                            {"error": {"code": "invalid_402", "message": body_bytes.decode(errors="replace")}},
-                        ) from exc
-                    accepts = body.get("accepts") if isinstance(body, dict) else None
+                        body = parse_payment_required(resp.headers, body_bytes)
+                    except ValueError as exc:
+                        raise _map_error(402, {"error": {"code": "invalid_402", "message": str(exc)}}) from exc
+                    accepts = body.get("accepts")
                     if (
                         not isinstance(accepts, list)
                         or not accepts
@@ -396,13 +389,10 @@ class AsyncTransport:
 
             if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                 try:
-                    body = resp.json()
-                except Exception as exc:
-                    raise _map_error(
-                        402,
-                        {"error": {"code": "invalid_402", "message": resp.text}},
-                    ) from exc
-                accepts = body.get("accepts") if isinstance(body, dict) else None
+                    body = parse_payment_required(resp.headers, resp.text)
+                except ValueError as exc:
+                    raise _map_error(402, {"error": {"code": "invalid_402", "message": str(exc)}}) from exc
+                accepts = body.get("accepts")
                 if not isinstance(accepts, list) or not accepts or not all(isinstance(item, dict) for item in accepts):
                     raise _map_error(
                         402,
@@ -460,15 +450,10 @@ class AsyncTransport:
                 if resp.status_code == 402 and self._payment_handler is not None and not payment_attempted:
                     body_bytes = await resp.aread()
                     try:
-                        import json as _json
-
-                        body = _json.loads(body_bytes)
-                    except Exception as exc:
-                        raise _map_error(
-                            402,
-                            {"error": {"code": "invalid_402", "message": body_bytes.decode(errors="replace")}},
-                        ) from exc
-                    accepts = body.get("accepts") if isinstance(body, dict) else None
+                        body = parse_payment_required(resp.headers, body_bytes)
+                    except ValueError as exc:
+                        raise _map_error(402, {"error": {"code": "invalid_402", "message": str(exc)}}) from exc
+                    accepts = body.get("accepts")
                     if (
                         not isinstance(accepts, list)
                         or not accepts

--- a/python/tests/test_sdk.py
+++ b/python/tests/test_sdk.py
@@ -1,5 +1,6 @@
 """Tests for AceDataCloud Python SDK."""
 
+import base64
 import json
 from unittest.mock import Mock
 
@@ -71,6 +72,33 @@ def test_x402_payment_retry_does_not_use_retry_budget():
 
     assert route.call_count == 2
     assert route.calls.last.request.headers["X-Payment"] == "signed-payment"
+    client.close()
+
+
+@respx.mock
+def test_x402_payment_retry_parses_payment_required_header():
+    required = {
+        "x402Version": 2,
+        "accepts": [{"network": "eip155:8453", "scheme": "exact", "amount": "1"}],
+    }
+    encoded = base64.b64encode(json.dumps(required).encode()).decode()
+    payment_handler = Mock(return_value={"headers": {"PAYMENT-SIGNATURE": "signed-payment"}})
+    route = respx.post("https://x402.acedata.cloud/openai/chat/completions").mock(
+        side_effect=[
+            httpx.Response(
+                402,
+                content=b"",
+                headers={"PAYMENT-REQUIRED": encoded},
+            ),
+            httpx.Response(200, json={"choices": []}),
+        ]
+    )
+    client = AceDataCloud(payment_handler=payment_handler, max_retries=0)
+
+    client.openai.chat.completions.create(model="test", messages=[])
+
+    assert payment_handler.call_args.args[0]["accepts"] == required["accepts"]
+    assert route.calls.last.request.headers["PAYMENT-SIGNATURE"] == "signed-payment"
     client.close()
 
 

--- a/typescript/src/runtime/payment.ts
+++ b/typescript/src/runtime/payment.ts
@@ -3,7 +3,7 @@
  *
  * When the API returns `402 Payment Required`, the transport calls the
  * configured `PaymentHandler` to produce the extra headers (typically
- * `X-Payment`) to attach to the retry. This keeps the SDK free of any
+ * `PAYMENT-SIGNATURE`) to attach to the retry. This keeps the SDK free of any
  * chain-specific signing logic, and lets callers plug in a real x402
  * implementation such as `@acedatacloud/x402-client`.
  */
@@ -12,7 +12,9 @@
 export interface PaymentRequirement {
   scheme: string;
   network: string;
-  maxAmountRequired: string;
+  amount?: string;
+  /** @deprecated Legacy challenge field. */
+  maxAmountRequired?: string;
   maxTimeoutSeconds?: number;
   resource?: string;
   description?: string;
@@ -38,7 +40,7 @@ export interface PaymentHandlerContext {
 
 /** Result a payment handler must return. */
 export interface PaymentHandlerResult {
-  /** Extra headers to attach to the retry (must include `X-Payment`). */
+  /** Extra headers to attach to the retry (normally `PAYMENT-SIGNATURE`). */
   headers: Record<string, string>;
 }
 

--- a/typescript/src/runtime/transport.ts
+++ b/typescript/src/runtime/transport.ts
@@ -17,6 +17,24 @@ import type {
   PaymentRequiredBody,
 } from './payment';
 
+function parsePaymentRequired(resp: Response, text: string): PaymentRequiredBody {
+  const encoded = resp.headers.get('PAYMENT-REQUIRED');
+  if (encoded) {
+    try {
+      return JSON.parse(atob(encoded)) as PaymentRequiredBody;
+    } catch {
+      throw mapError(402, {
+        error: { code: 'invalid_402', message: 'Invalid PAYMENT-REQUIRED header' },
+      });
+    }
+  }
+  try {
+    return JSON.parse(text) as PaymentRequiredBody;
+  } catch {
+    throw mapError(402, { error: { code: 'invalid_402', message: text } });
+  }
+}
+
 const ERROR_CODE_MAP: Record<string, typeof APIError> = {
   invalid_token: AuthenticationError,
   token_expired: AuthenticationError,
@@ -171,12 +189,7 @@ export class Transport {
 
         if (resp.status === 402 && this.paymentHandler && !paymentAttempted) {
           const text = await resp.text();
-          let body: unknown;
-          try {
-            body = JSON.parse(text);
-          } catch {
-            throw mapError(402, { error: { code: 'invalid_402', message: text } });
-          }
+          const body = parsePaymentRequired(resp, text);
           if (
             !body ||
             typeof body !== 'object' ||
@@ -267,12 +280,7 @@ export class Transport {
 
         if (resp.status === 402 && this.paymentHandler && !paymentAttempted) {
           const text = await resp.text();
-          let body: unknown;
-          try {
-            body = JSON.parse(text);
-          } catch {
-            throw mapError(402, { error: { code: 'invalid_402', message: text } });
-          }
+          const body = parsePaymentRequired(resp, text);
           if (
             !body ||
             typeof body !== 'object' ||

--- a/typescript/tests/transport.test.ts
+++ b/typescript/tests/transport.test.ts
@@ -66,6 +66,35 @@ describe('Transport API base URL', () => {
     expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({ 'X-Payment': 'signed-payment' });
   });
 
+  it('parses PAYMENT-REQUIRED when the 402 body has no accepts list', async () => {
+    const paymentHandler = jest.fn().mockResolvedValue({
+      headers: { 'PAYMENT-SIGNATURE': 'signed-payment' },
+    });
+    const required = {
+      x402Version: 2,
+      accepts: [{ network: 'eip155:8453', scheme: 'exact', amount: '1' }],
+    };
+    const fetchMock = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'payment required' }), {
+          status: 402,
+          headers: { 'PAYMENT-REQUIRED': btoa(JSON.stringify(required)) },
+        })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const transport = new Transport({ paymentHandler, maxRetries: 0 });
+    await transport.request('GET', '/paid');
+
+    expect(paymentHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ accepts: required.accepts })
+    );
+    expect(fetchMock.mock.calls[1][1]?.headers).toMatchObject({
+      'PAYMENT-SIGNATURE': 'signed-payment',
+    });
+  });
+
   it('does not retry a paid request with the same signature', async () => {
     const paymentHandler = jest.fn().mockResolvedValue({
       headers: { 'X-Payment': 'signed-payment' },


### PR DESCRIPTION
## Summary
- parse base64 `PAYMENT-REQUIRED` before the response body in TypeScript, Python, and Go
- pass canonical requirements to payment handlers and retry with `PAYMENT-SIGNATURE`
- support empty 402 bodies and reject malformed headers consistently
- add x402 payment retry to Go streaming requests

## Validation
- TypeScript: 47 passed, 27 skipped; build and typecheck clean
- Python: 70 passed, 29 skipped; Ruff lint/format clean
- Go: `go test ./...` passed

## Dependency
Release after the Gateway v2 lane and X402Client official payload changes are available.

## Adversarial Review (reviewer: github-copilot-subagent, 2 rounds)
- RISK: Python parsed body before a valid header - fixed with header-first parsing
- RISK: Go streaming did not invoke payment handler - fixed with one-shot v2 retry and regression coverage
- RISK: Go tolerated malformed mixed `accepts` and Python masked malformed headers - fixed with strict cross-SDK validation
- Baseline upload/empty-200 behavior - rebutted as outside this transport-header diff
