### PR TITLE
fix(sdk): 带产物的 success:false 是失败，不是成功

### DIFF
--- a/python/src/acedatacloud/_runtime/tasks.py
+++ b/python/src/acedatacloud/_runtime/tasks.py
@@ -99,6 +99,14 @@ def task_status(state: dict[str, Any]) -> str:
         # A non-terminal word (queued, processing, …) means keep waiting.
         return ""
 
+    # No status word at all. `success: false` on its own is ambiguous — some
+    # services use it for a retryable hiccup mid-run, and the task tests pin
+    # that — but paired with an artifact the job has clearly finished, and
+    # finished unsuccessfully. Without this, such a response reaches the caller
+    # as a success.
+    if response.get("success") is False and artifact_urls(state):
+        return "failed"
+
     finished = response.get("finished_at") is not None or state.get("finished_at") is not None
     if finished:
         if response.get("success") is True:

--- a/python/tests/test_providers.py
+++ b/python/tests/test_providers.py
@@ -159,3 +159,21 @@ def test_handle_is_born_complete_when_the_server_answered_synchronously(client):
     assert handle.wait() is not None
     assert handle.urls() == ["https://cdn.example.com/a.png"]
     assert transport.request.call_count == 1, "wait() must not poll a finished task"
+
+
+def test_success_false_with_an_artifact_is_a_failure():
+    """A finished-but-unsuccessful response must not be delivered as a success.
+
+    `success: false` alone is ambiguous — some services use it for a retryable
+    hiccup mid-run — but paired with an artifact the job has clearly ended.
+    """
+    from acedatacloud._runtime.tasks import task_status
+
+    state = {"response": {"success": False, "video_url": "https://cdn.example.com/x.mp4"}}
+    assert task_status(state) == "failed"
+
+
+def test_success_false_without_an_artifact_keeps_waiting():
+    from acedatacloud._runtime.tasks import task_status
+
+    assert task_status({"response": {"success": False, "error": "temporary"}}) == ""


### PR DESCRIPTION
## 问题

`{"response": {"success": false, "video_url": "https://…"}}` 被判成 **succeeded** —— 调用方会把一个失败的生成当成功交付给用户。

迁移 Discord bot 到 SDK 时发现的：bot 自己的测试里记录了这个来自真实上游响应的场景。

## 为什么不能简单地「`success: false` 就是失败」

因为它本身是有歧义的 —— 有些服务在任务**仍在运行**时用它表示可重试的瞬时错误。既有的 task 测试正好钉住了这一点（`{"success": false, "error": "temporary"}` 必须继续等）。

**产物的存在与否才是区分点**：有 URL 说明任务已经跑完了，跑完且不成功 = 失败。

```
success:false + 产物  → failed   （已完成，失败）
success:false 无产物  → ""       （可能瞬时，继续等）
```

155 个测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)