### PR TITLE
fix(sdk): get() 必须记录终态

### DIFF
--- a/go/client_test.go
+++ b/go/client_test.go
@@ -335,3 +335,51 @@ func TestImages_GenerateReturnsTaskHandle(t *testing.T) {
 		t.Fatalf("bad url: %+v", resp)
 	}
 }
+
+// TestGetRecordsTerminalState covers the parity fix: a caller driving its own
+// poll loop only ever calls Get, so Get is where completion must be recorded.
+// Without it, URLs stays empty after a task has plainly finished.
+func TestGetRecordsTerminalState(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"response":{"success":true,"finished_at":"2026-07-27T09:38:41Z",
+			"data":[{"image_url":"https://cdn.example.com/a.png"}]}}`))
+	}))
+	defer server.Close()
+
+	c, err := NewClient(WithAPIToken("t"), WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	h := newTaskHandle("task-1", "/flux/tasks", c.transport, nil)
+	if h.Done() {
+		t.Fatal("handle should not start complete")
+	}
+
+	if _, err := h.Get(context.Background()); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !h.Done() {
+		t.Error("Get must record a terminal state")
+	}
+	if urls := h.URLs(); len(urls) != 1 || urls[0] != "https://cdn.example.com/a.png" {
+		t.Errorf("URLs after Get = %v, want the artifact", urls)
+	}
+}
+
+func TestGetLeavesRunningTaskAlone(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"response":{"status":"processing"}}`))
+	}))
+	defer server.Close()
+
+	c, _ := NewClient(WithAPIToken("t"), WithBaseURL(server.URL))
+	h := newTaskHandle("task-1", "/flux/tasks", c.transport, nil)
+	if _, err := h.Get(context.Background()); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if h.Done() {
+		t.Error("a running task must not be marked complete")
+	}
+}

--- a/go/tasks.go
+++ b/go/tasks.go
@@ -39,7 +39,11 @@ func (h *TaskHandle) URLs() []string { return ArtifactURLs(h.last) }
 // Progress returns percent complete, or nil when the service does not report it.
 func (h *TaskHandle) Progress() *int { return TaskProgress(h.last) }
 
-// Get fetches the current task state from the server.
+// Get fetches the current task state, remembering it once terminal.
+//
+// A caller that drives its own poll loop — checking status between polls so it
+// can report progress — only ever calls this. Without recording completion here,
+// URLs and Result would stay empty after the task had plainly finished.
 func (h *TaskHandle) Get(ctx context.Context) (map[string]any, error) {
 	state, err := h.transport.do(ctx, requestOpts{
 		Method: "POST",
@@ -50,6 +54,9 @@ func (h *TaskHandle) Get(ctx context.Context) (map[string]any, error) {
 		return nil, err
 	}
 	h.last = state
+	if terminalStatus(state) {
+		h.done = true
+	}
 	return state, nil
 }
 
@@ -85,8 +92,7 @@ func (h *TaskHandle) Wait(ctx context.Context, pollInterval, maxWait time.Durati
 		if err != nil {
 			return nil, err
 		}
-		if terminalStatus(state) {
-			h.done = true
+		if h.done {
 			return state, nil
 		}
 		if time.Now().After(deadline) {

--- a/python/src/acedatacloud/_runtime/tasks.py
+++ b/python/src/acedatacloud/_runtime/tasks.py
@@ -217,17 +217,26 @@ class TaskHandle(_HandleBase):
     """Synchronous handle for a long-running task."""
 
     def get(self) -> dict[str, Any]:
-        """Fetch current task state."""
-        return self._transport.request(
+        """Fetch current task state, remembering it once terminal.
+
+        A caller that drives its own poll loop — checking status between polls so
+        it can report progress — only ever calls this. If a terminal response
+        were not recorded here, `urls()` and `result()` would stay empty after
+        the task had plainly finished.
+        """
+        state = self._transport.request(
             "POST",
             self._poll_endpoint,
             json={"id": self.id, "action": "retrieve"},
         )
+        self._accept(state)
+        return state
 
     def is_completed(self) -> bool:
         if self.done:
             return True
-        return self._accept(self.get()) in ("succeeded", "failed")
+        self.get()  # records a terminal state as a side effect
+        return self.done
 
     def wait(
         self,
@@ -241,7 +250,7 @@ class TaskHandle(_HandleBase):
         start = time.monotonic()
         while time.monotonic() - start < max_wait:
             state = self.get()
-            if self._accept(state) in ("succeeded", "failed"):
+            if self.done:
                 return state
             time.sleep(poll_interval)
         raise TimeoutError(f"Task {self.id} did not complete within {max_wait}s")
@@ -254,16 +263,20 @@ class AsyncTaskHandle(_HandleBase):
     """Asynchronous handle for a long-running task."""
 
     async def get(self) -> dict[str, Any]:
-        return await self._transport.request(
+        """Fetch current task state, remembering it once terminal."""
+        state = await self._transport.request(
             "POST",
             self._poll_endpoint,
             json={"id": self.id, "action": "retrieve"},
         )
+        self._accept(state)
+        return state
 
     async def is_completed(self) -> bool:
         if self.done:
             return True
-        return self._accept(await self.get()) in ("succeeded", "failed")
+        await self.get()  # records a terminal state as a side effect
+        return self.done
 
     async def wait(
         self,
@@ -276,7 +289,7 @@ class AsyncTaskHandle(_HandleBase):
         start = time.monotonic()
         while time.monotonic() - start < max_wait:
             state = await self.get()
-            if self._accept(state) in ("succeeded", "failed"):
+            if self.done:
                 return state
             await asyncio.sleep(poll_interval)
         raise TimeoutError(f"Task {self.id} did not complete within {max_wait}s")

--- a/python/tests/test_providers.py
+++ b/python/tests/test_providers.py
@@ -177,3 +177,47 @@ def test_success_false_without_an_artifact_keeps_waiting():
     from acedatacloud._runtime.tasks import task_status
 
     assert task_status({"response": {"success": False, "error": "temporary"}}) == ""
+
+
+def test_get_records_a_terminal_state(client):
+    """A caller driving its own poll loop only ever calls get().
+
+    Without recording here, urls() and result() stay empty after a task has
+    plainly finished — the failure looks like "generation succeeded but produced
+    nothing", which is worse than an error.
+    """
+    from unittest.mock import Mock
+
+    transport = Mock()
+    transport.request.return_value = {"task_id": "t-1"}
+    client.flux._transport = transport
+    handle = client.flux.generate(action="generate", prompt="a cat")
+    assert not handle.done
+
+    transport.request.return_value = {
+        "response": {
+            "success": True,
+            "finished_at": "2026-07-27T09:38:41Z",
+            "data": [{"image_url": "https://cdn.example.com/a.png"}],
+        }
+    }
+    handle.get()
+
+    assert handle.done
+    assert handle.urls() == ["https://cdn.example.com/a.png"]
+    assert handle.result() is not None
+
+
+def test_get_leaves_a_running_task_alone(client):
+    from unittest.mock import Mock
+
+    transport = Mock()
+    transport.request.return_value = {"task_id": "t-1"}
+    client.flux._transport = transport
+    handle = client.flux.generate(action="generate", prompt="a cat")
+
+    transport.request.return_value = {"response": {"status": "processing"}}
+    handle.get()
+
+    assert not handle.done
+    assert handle.urls() == []

--- a/typescript/src/runtime/tasks.ts
+++ b/typescript/src/runtime/tasks.ts
@@ -184,16 +184,32 @@ export class TaskHandle {
     return taskProgress(this._result);
   }
 
+  /**
+   * Fetch current task state, remembering it once terminal.
+   *
+   * A caller that drives its own poll loop — checking status between polls so it
+   * can report progress — only ever calls this. Without recording here, urls()
+   * and result() stay empty after the task has plainly finished.
+   */
   async get(): Promise<Record<string, unknown>> {
-    return this.transport.request('POST', this.pollEndpoint, {
+    const state = await this.transport.request('POST', this.pollEndpoint, {
       json: { id: this.id, action: 'retrieve' },
     });
+    this.accept(state);
+    return state;
+  }
+
+  private accept(state: Record<string, unknown>): void {
+    const status = taskStatus(state);
+    if (status === 'succeeded' || status === 'failed') {
+      this._result = state;
+    }
   }
 
   async isCompleted(): Promise<boolean> {
     if (this.done) return true;
-    const status = taskStatus(await this.get());
-    return status === 'succeeded' || status === 'failed';
+    await this.get(); // records a terminal state as a side effect
+    return this.done;
   }
 
   async wait(opts: TaskHandleOptions = {}): Promise<Record<string, unknown>> {
@@ -205,12 +221,7 @@ export class TaskHandle {
 
     while (Date.now() - start < maxWait) {
       const state = await this.get();
-      const status = taskStatus(state);
-
-      if (status === 'succeeded' || status === 'failed') {
-        this._result = state;
-        return state;
-      }
+      if (this.done) return state;
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
     throw new Error(`Task ${this.id} did not complete within ${maxWait}ms`);

--- a/typescript/tests/tasks.test.ts
+++ b/typescript/tests/tasks.test.ts
@@ -55,3 +55,49 @@ describe('TaskHandle', () => {
     await expect(handle.isCompleted()).resolves.toBe(expected);
   });
 });
+describe('get() records a terminal state', () => {
+  // The parity fix: a caller driving its own poll loop only ever calls get(),
+  // so get() is where completion must be recorded. Without it, urls() stays
+  // empty after a task has plainly finished.
+  const finished = {
+    response: {
+      success: true,
+      finished_at: '2026-07-27T09:38:41Z',
+      data: [{ image_url: 'https://cdn.example.com/a.png' }],
+    },
+  };
+
+  it('marks the handle done and exposes the artifact', async () => {
+    const transport = { request: jest.fn().mockResolvedValue(finished) } as never;
+    const handle = new TaskHandle('task-1', '/flux/tasks', transport);
+    expect(handle.done).toBe(false);
+
+    await handle.get();
+
+    expect(handle.done).toBe(true);
+    expect(handle.urls()).toEqual(['https://cdn.example.com/a.png']);
+    expect(handle.result).not.toBeNull();
+  });
+
+  it('leaves a running task alone', async () => {
+    const transport = {
+      request: jest.fn().mockResolvedValue({ response: { status: 'processing' } }),
+    } as never;
+    const handle = new TaskHandle('task-1', '/flux/tasks', transport);
+
+    await handle.get();
+
+    expect(handle.done).toBe(false);
+    expect(handle.urls()).toEqual([]);
+  });
+
+  it('does not poll again once complete', async () => {
+    const request = jest.fn().mockResolvedValue(finished);
+    const handle = new TaskHandle('task-1', '/flux/tasks', { request } as never);
+
+    await handle.get();
+    await handle.wait();
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 症状

任务判成 `succeeded`，但 `handle.urls()` 返回空 —— **用户会看到「生成成功」却没有结果**。

## 根因

自己驱动轮询循环的调用方（为了在轮询间隙报告进度）**只会调 `get()`**。而 `get()` 是纯读取，不写 `_result` —— 只有 `wait()` 和 `is_completed()` 会。所以任务明明结束了，`urls()` 和 `result()` 仍然是空的。

这是通过**用 Discord bot 完全相同的轮询形态跑一次真实生成**发现的。单元测试和之前的线上验证都没抓到 —— 因为它们走的是 `wait()`。

```python
# 真实调用方的写法（discordace 的 _poll）
while ...:
    state = await handle.get()      # 这里拿到了终态
    if task_status(state): break
print(handle.urls())                 # 但这里是空的
```

## 修复

`get()` 观察到终态时记录下来。`wait()` 和 `is_completed()` 改为依赖它而不是各自判断 —— **判定任务结束只有一个地方**。

## 验证

157 个测试通过。真实 flux 生成、外部轮询循环驱动：

```
[  5.7s] running
[ 11.3s] running
[ 16.9s] running
[ 22.5s] succeeded
handle.urls() -> ['https://platform2.cdn.acedata.cloud/flux/208a5253-….png']
VERDICT: PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)