### PR TITLE
fix(sdk): 按模态选服务主端点，而非 spec 顺序

### DIFF
--- a/go/provider_digitalhuman.go
+++ b/go/provider_digitalhuman.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Digitalhuman is the digitalhuman provider client.
 type Digitalhuman struct {
 	t *transport

--- a/go/provider_dreamina.go
+++ b/go/provider_dreamina.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Dreamina is the dreamina provider client.
 type Dreamina struct {
 	t *transport
@@ -12,7 +13,7 @@ type Dreamina struct {
 
 // DreaminaGenerateRequest is the input to dreamina.Generate.
 type DreaminaGenerateRequest struct {
-	// Public URL for audio (mp3/wav). The character will lip-sync to it, and it is recommended that the duration be
+	// Public URL for audio (mp3/wav). The character will lip-sync to it, and it is recommended that the duration be 
 	AudioURL string
 	// Public URL of portrait images. Clear frontal face effects are best.
 	ImageURL string

--- a/go/provider_fish.go
+++ b/go/provider_fish.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Fish is the fish provider client.
 type Fish struct {
 	t *transport
@@ -146,7 +147,7 @@ type FishModelRequest struct {
 	Description string
 	// If it is `true`, the upstream service will generate a sample voice after the training is completed.
 	GenerateSample bool
-	// If it is `true`, the upstream service will perform quality enhancement processing on the audio samples before
+	// If it is `true`, the upstream service will perform quality enhancement processing on the audio samples before 
 	EnhanceAudioQuality bool
 	// CallbackURL optionally receives the completion webhook.
 	CallbackURL string

--- a/go/provider_flux.go
+++ b/go/provider_flux.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Flux is the flux provider client.
 type Flux struct {
 	t *transport

--- a/go/provider_hailuo.go
+++ b/go/provider_hailuo.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Hailuo is the hailuo provider client.
 type Hailuo struct {
 	t *transport
@@ -57,7 +58,7 @@ func (r HailuoGenerateRequest) toBody() map[string]any {
 	return body
 }
 
-// Generate Minimax Hailuo AI video generation API. Supports minimax-t2v for text-to-video, minimax-i2v for image-to-video, and minimax-i2v-director for director
+// Generate Minimax Hailuo AI video generation API. Supports minimax-t2v for text-to-video, minimax-i2v for image-to-video, and minimax-i2v-director for director 
 func (c *Hailuo) Generate(ctx context.Context, req HailuoGenerateRequest) (*TaskHandle, error) {
 	result, err := c.t.do(ctx, requestOpts{
 		Method: "POST",

--- a/go/provider_happyhorse.go
+++ b/go/provider_happyhorse.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Happyhorse is the happyhorse provider client.
 type Happyhorse struct {
 	t *transport
@@ -16,7 +17,7 @@ type HappyhorseGenerateRequest struct {
 	Seed int
 	// HappyHorse model name. Different actions only support the corresponding model family.
 	Model string
-	// Output video aspect ratio. Text-to-video and reference image-to-video support this parameter; the first frame
+	// Output video aspect ratio. Text-to-video and reference image-to-video support this parameter; the first frame 
 	Ratio string
 	// Operation types. `generate` is for generating video from text, `image_to_video` is for generating video from t
 	Action string

--- a/go/provider_localization.go
+++ b/go/provider_localization.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Localization is the localization provider client.
 type Localization struct {
 	t *transport

--- a/go/provider_luma.go
+++ b/go/provider_luma.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Luma is the luma provider client.
 type Luma struct {
 	t *transport
@@ -22,7 +23,7 @@ type LumaGenerateRequest struct {
 	Timeout float64
 	// The unique identifier of the generated video used for the continuation operation (`extend`). If both are speci
 	VideoID string
-	// The original video URL used for the extend operation (`extend`). If `video_id` is specified at the same time,
+	// The original video URL used for the extend operation (`extend`). If `video_id` is specified at the same time, 
 	VideoURL string
 	// Whether to enable automatic optimization enhancement for the input prompt text, suitable for use when unsure h
 	Enhancement bool

--- a/go/provider_maestro.go
+++ b/go/provider_maestro.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Maestro is the maestro provider client.
 type Maestro struct {
 	t *transport
@@ -24,7 +25,7 @@ type MaestroGenerateRequest struct {
 	Action string
 	// Output aspect ratio (hint — the agent may follow the prompt).
 	Aspect string
-	// Production tier, a multiplier on the duration-based price. `draft` = a fast rough cut for previewing the idea
+	// Production tier, a multiplier on the duration-based price. `draft` = a fast rough cut for previewing the idea 
 	Quality string
 	// Target video length in seconds (1–600, i.e. up to 10 minutes). Billed by duration: credits ≈ 0.85 × duration ×
 	Duration int

--- a/go/provider_nano_banana.go
+++ b/go/provider_nano_banana.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // NanoBanana is the nano-banana provider client.
 type NanoBanana struct {
 	t *transport
@@ -18,7 +19,7 @@ type NanoBananaGenerateRequest struct {
 	Prompt string
 	// The number of images to be generated or edited supports 1 to 4, with a default of 1. If some images fail to ge
 	Count int
-	// Models used for generating images. If not specified, the default is `nano-banana`. `nano-banana-2-lite` is an
+	// Models used for generating images. If not specified, the default is `nano-banana`. `nano-banana-2-lite` is an 
 	Model string
 	// Link to the image that needs to be edited. It can be an accessible http or https URL, or a Base64 encoded imag
 	ImageURLs []string

--- a/go/provider_producer.go
+++ b/go/provider_producer.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Producer is the producer provider client.
 type Producer struct {
 	t *transport
@@ -43,8 +44,8 @@ func (c *Producer) Upload(ctx context.Context, req ProducerUploadRequest) (map[s
 	})
 }
 
-// ProducerGenerateRequest is the input to producer.Generate.
-type ProducerGenerateRequest struct {
+// ProducerVideosRequest is the input to producer.Videos.
+type ProducerVideosRequest struct {
 	// Reference audio ID.
 	AudioID string
 	// CallbackURL optionally receives the completion webhook.
@@ -53,7 +54,7 @@ type ProducerGenerateRequest struct {
 	Extra map[string]any
 }
 
-func (r ProducerGenerateRequest) toBody() map[string]any {
+func (r ProducerVideosRequest) toBody() map[string]any {
 	body := map[string]any{}
 	body["audio_id"] = r.AudioID
 	if r.CallbackURL != "" {
@@ -67,8 +68,8 @@ func (r ProducerGenerateRequest) toBody() map[string]any {
 	return body
 }
 
-// Generate AceData Producer MP4 retrieval API. Pass an audio_id to receive an MP4 video download link with cover art.
-func (c *Producer) Generate(ctx context.Context, req ProducerGenerateRequest) (map[string]any, error) {
+// Videos AceData Producer MP4 retrieval API. Pass an audio_id to receive an MP4 video download link with cover art.
+func (c *Producer) Videos(ctx context.Context, req ProducerVideosRequest) (map[string]any, error) {
 	return c.t.do(ctx, requestOpts{
 		Method: "POST",
 		Path:   "/producer/videos",
@@ -109,8 +110,8 @@ func (c *Producer) Wav(ctx context.Context, req ProducerWavRequest) (map[string]
 	})
 }
 
-// ProducerProducerAudiosRequest is the input to producer.Producer_Audios.
-type ProducerProducerAudiosRequest struct {
+// ProducerGenerateRequest is the input to producer.Generate.
+type ProducerGenerateRequest struct {
 	// Lyrics content for generating audio.
 	Lyric string
 	// Types of audio generation operations. Supported values include `generate` (generate based on prompts), `cover`
@@ -149,7 +150,7 @@ type ProducerProducerAudiosRequest struct {
 	Extra map[string]any
 }
 
-func (r ProducerProducerAudiosRequest) toBody() map[string]any {
+func (r ProducerGenerateRequest) toBody() map[string]any {
 	body := map[string]any{}
 	body["lyric"] = r.Lyric
 	body["action"] = r.Action
@@ -213,8 +214,8 @@ func (r ProducerProducerAudiosRequest) toBody() map[string]any {
 	return body
 }
 
-// ProducerAudios Producer AI music generation API, generates 1 song per request.
-func (c *Producer) ProducerAudios(ctx context.Context, req ProducerProducerAudiosRequest) (*TaskHandle, error) {
+// Generate Producer AI music generation API, generates 1 song per request.
+func (c *Producer) Generate(ctx context.Context, req ProducerGenerateRequest) (*TaskHandle, error) {
 	result, err := c.t.do(ctx, requestOpts{
 		Method: "POST",
 		Path:   "/producer/audios",

--- a/go/provider_seedance.go
+++ b/go/provider_seedance.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Seedance is the seedance provider client.
 type Seedance struct {
 	t *transport

--- a/go/provider_seedream.go
+++ b/go/provider_seedream.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Seedream is the seedream provider client.
 type Seedream struct {
 	t *transport
@@ -16,7 +17,7 @@ type SeedreamGenerateRequest struct {
 	Model string
 	// Prompts for generating images.
 	Prompt string
-	// Generate a random seed for image generation. The supported range is [-1, 2147483647], with a default value of
+	// Generate a random seed for image generation. The supported range is [-1, 2147483647], with a default value of 
 	Seed int
 	// Generate image dimensions or aspect ratios. Supports preset options (`1K`/`2K`/`3K`/`4K`), `adaptive` (adaptiv
 	Size string

--- a/go/provider_suno.go
+++ b/go/provider_suno.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Suno is the suno provider client.
 type Suno struct {
 	t *transport
@@ -18,7 +19,7 @@ type SunoGenerateRequest struct {
 	Model string
 	// Music style description. `chirp-v3-5` and `chirp-v4` up to 200 characters; `chirp-v4-5` and above (including `
 	Style string
-	// Music Title (Custom Mode). `chirp-v3-5` and `chirp-v4` up to 80 characters; `chirp-v4-5` and above (including
+	// Music Title (Custom Mode). `chirp-v3-5` and `chirp-v4` up to 80 characters; `chirp-v4-5` and above (including 
 	Title string
 	// Types of operations for generating music. `generate`: Generate audio based on prompts; `extend`: Continue gene
 	Action string

--- a/go/provider_wan.go
+++ b/go/provider_wan.go
@@ -5,6 +5,7 @@ package acedatacloud
 
 import "context"
 
+
 // Wan is the wan provider client.
 type Wan struct {
 	t *transport
@@ -32,7 +33,7 @@ type WanGenerateRequest struct {
 	ShotType string
 	// Specify the resolution level for generating the video, used to adjust the video clarity (total pixel count). T
 	Resolution string
-	// Whether to enable intelligent rewriting of prompts. Once enabled, a large model will be used to intelligently
+	// Whether to enable intelligent rewriting of prompts. Once enabled, a large model will be used to intelligently 
 	PromptExtend bool
 	// Reverse prompt words, used to describe content that is not desired to appear in the video footage, can be used
 	NegativePrompt string

--- a/go/providers_attach.go
+++ b/go/providers_attach.go
@@ -3,6 +3,7 @@
 
 package acedatacloud
 
+
 // taskIDFrom pulls a task id out of a submission response.
 func taskIDFrom(result map[string]any) string {
 	if s, ok := result["task_id"].(string); ok && s != "" {
@@ -22,39 +23,39 @@ func taskIDFrom(result map[string]any) string {
 // providers holds the provider-axis clients, one per service.
 type providers struct {
 	digitalhuman *Digitalhuman
-	dreamina     *Dreamina
-	fish         *Fish
-	flux         *Flux
-	hailuo       *Hailuo
-	happyhorse   *Happyhorse
+	dreamina *Dreamina
+	fish *Fish
+	flux *Flux
+	hailuo *Hailuo
+	happyhorse *Happyhorse
 	localization *Localization
-	luma         *Luma
-	maestro      *Maestro
-	nanobanana   *NanoBanana
-	producer     *Producer
-	seedance     *Seedance
-	seedream     *Seedream
-	suno         *Suno
-	wan          *Wan
+	luma *Luma
+	maestro *Maestro
+	nanobanana *NanoBanana
+	producer *Producer
+	seedance *Seedance
+	seedream *Seedream
+	suno *Suno
+	wan *Wan
 }
 
 func newProviders(tr *transport) *providers {
 	return &providers{
 		digitalhuman: &Digitalhuman{t: tr},
-		dreamina:     &Dreamina{t: tr},
-		fish:         &Fish{t: tr},
-		flux:         &Flux{t: tr},
-		hailuo:       &Hailuo{t: tr},
-		happyhorse:   &Happyhorse{t: tr},
+		dreamina: &Dreamina{t: tr},
+		fish: &Fish{t: tr},
+		flux: &Flux{t: tr},
+		hailuo: &Hailuo{t: tr},
+		happyhorse: &Happyhorse{t: tr},
 		localization: &Localization{t: tr},
-		luma:         &Luma{t: tr},
-		maestro:      &Maestro{t: tr},
-		nanobanana:   &NanoBanana{t: tr},
-		producer:     &Producer{t: tr},
-		seedance:     &Seedance{t: tr},
-		seedream:     &Seedream{t: tr},
-		suno:         &Suno{t: tr},
-		wan:          &Wan{t: tr},
+		luma: &Luma{t: tr},
+		maestro: &Maestro{t: tr},
+		nanobanana: &NanoBanana{t: tr},
+		producer: &Producer{t: tr},
+		seedance: &Seedance{t: tr},
+		seedream: &Seedream{t: tr},
+		suno: &Suno{t: tr},
+		wan: &Wan{t: tr},
 	}
 }
 
@@ -102,3 +103,4 @@ func (c *Client) Suno() *Suno { return c.providers.suno }
 
 // Wan returns the wan provider client.
 func (c *Client) Wan() *Wan { return c.providers.wan }
+

--- a/python/src/acedatacloud/resources/providers/producer.py
+++ b/python/src/acedatacloud/resources/providers/producer.py
@@ -66,7 +66,7 @@ class Producer:
             body["callback_url"] = callback_url
         return self._transport.request("POST", "/producer/upload", json=body)
 
-    def generate(
+    def videos(
         self,
         *,
         audio_id: str,
@@ -96,7 +96,7 @@ class Producer:
             body["callback_url"] = callback_url
         return self._transport.request("POST", "/producer/wav", json=body)
 
-    def producer_audios(
+    def generate(
         self,
         *,
         lyric: str,
@@ -190,7 +190,7 @@ class AsyncProducer:
             body["callback_url"] = callback_url
         return await self._transport.request("POST", "/producer/upload", json=body)
 
-    async def generate(
+    async def videos(
         self,
         *,
         audio_id: str,
@@ -220,7 +220,7 @@ class AsyncProducer:
             body["callback_url"] = callback_url
         return await self._transport.request("POST", "/producer/wav", json=body)
 
-    async def producer_audios(
+    async def generate(
         self,
         *,
         lyric: str,

--- a/scripts/genlib/model.py
+++ b/scripts/genlib/model.py
@@ -131,9 +131,20 @@ class Param:
 
 
 # The last path segment names the artifact ("/flux/images"), but a method reads
-# better as a verb. Only the primary generation endpoint is renamed; secondary
-# ones keep their own noun, which is what distinguishes them.
+# better as a verb. Exactly one endpoint per service becomes `generate`; the
+# others keep their own noun, which is what distinguishes them.
 _PRIMARY = {"images", "videos", "audios", "tts"}
+
+# Which artifact a service is really about. Producer exposes /producer/videos
+# (render a finished track to video) alongside /producer/audios (write the
+# music) — picking whichever came first in the spec listing made
+# `producer.generate` mean "render a video", so calling it demanded an audio_id
+# the caller had no way to have.
+_MODALITY_PRIMARY = {
+    "AI Image": "images",
+    "AI Video": "videos",
+    "AI Audio": "audios",
+}
 
 
 def _method_name(path: str) -> str:
@@ -171,9 +182,29 @@ class Service:
             if not spec_file.exists():
                 continue
             self.endpoints.append(Endpoint(alias, ep["path"], json.loads(spec_file.read_text())))
+        self._name_methods()
+
+    def _name_methods(self) -> None:
+        """Give exactly one endpoint the name `generate`, and make it the right one."""
+        want = _MODALITY_PRIMARY.get(self.category)
+        primary = None
+        if want:
+            primary = next(
+                (e for e in self.endpoints if snake(e.path.rsplit("/", 1)[-1]) == want), None
+            )
+        if primary is None:
+            primary = next((e for e in self.endpoints if e.method == "generate"), None)
+
+        for ep in self.endpoints:
+            if ep is primary:
+                ep.method = "generate"
+            elif ep.method == "generate":
+                # Lost the claim; fall back to its own noun.
+                ep.method = snake(ep.path.rsplit("/", 1)[-1]) or snake(ep.path.replace("/", "_"))
+
         seen: set[str] = set()
         for ep in self.endpoints:
-            # Two endpoints under one service can end in the same word.
+            # Two endpoints under one service can still end in the same word.
             if ep.method in seen:
                 ep.method = snake(ep.path.replace("/", "_"))
             seen.add(ep.method)

--- a/typescript/src/resources/providers/producer.ts
+++ b/typescript/src/resources/providers/producer.ts
@@ -24,7 +24,7 @@ export interface ProducerUploadOptions {
   [key: string]: unknown;
 }
 
-export interface ProducerGenerateOptions {
+export interface ProducerVideosOptions {
   /** Reference audio ID. */
   audioId: string;
   callbackUrl?: string;
@@ -40,7 +40,7 @@ export interface ProducerWavOptions {
   [key: string]: unknown;
 }
 
-export interface ProducerProducerAudiosOptions {
+export interface ProducerGenerateOptions {
   /** Lyrics content for generating audio. */
   lyric: string;
   /** Types of audio generation operations. Supported values include `generate` (generate based on prompts), `cover` (cover song), `extend` (continue writing), `variation` (variant), `swap_vocals` (replace vocals), `swap_instrumentals` (replace instrumentals), `replace_section` (replace section), `stems` (separate tracks). */
@@ -108,7 +108,7 @@ export class Producer {
   }
 
   /** AceData Producer MP4 retrieval API. Pass an audio_id to receive an MP4 video download link with cover art. */
-  async generate(options: ProducerGenerateOptions): Promise<Record<string, unknown>> {
+  async videos(options: ProducerVideosOptions): Promise<Record<string, unknown>> {
     const body: Record<string, unknown> = {};
     body["audio_id"] = options.audioId;
     for (const [key, value] of Object.entries(options)) {
@@ -134,7 +134,7 @@ export class Producer {
   }
 
   /** Producer AI music generation API, generates 1 song per request. */
-  async producer_audios(options: ProducerProducerAudiosOptions): Promise<TaskHandle> {
+  async generate(options: ProducerGenerateOptions): Promise<TaskHandle> {
     const body: Record<string, unknown> = {};
     body["lyric"] = options.lyric;
     body["action"] = options.action;


### PR DESCRIPTION
## 问题

`client.producer.generate()` 指向 `/producer/videos` —— 那是「把已完成的曲子渲染成视频」，所以调用它会要求一个 `audio_id`，而用户根本无从获得。

生成器把**第一个**以 images/videos/audios 结尾的端点命名为 `generate`，而 producer 的端点列表里 `/producer/videos` 排在 `/producer/audios` 前面。

## 修复

主端点改为**按服务自身的模态**选取：一个 AI Audio 服务生成的是音频，不管它的端点以什么顺序出现。落选的端点回退到自己的名词。

## 线上验证

```
producer.generate now targets /producer/audios:
  ACCEPTED task=3f61ecdc
```

只用 prompt + lyric 即被接受。

## 顺带查证的一件事

排查时发现 `kling.generate` 的 `model` 是必填，而它的 spec 只声明 `action` 必填 —— 看起来像手写类漂移了。

**实测证明不是**：上游确实拒绝没有 model 的 kling 请求。

```
kling without an explicit model:
  ValidationError: model is required
```

所以是 **spec 的 required 列表不全，手写类是对的** —— 这正是 `HAND_WRITTEN` 名单存在的意义（保留 spec 表达不了的知识）。我一度改成可选，验证后已撤回。

🤖 Generated with [Claude Code](https://claude.com/claude-code)