### PR TITLE
fix(sdk): 结构化错误是终态，即使没有 finished_at

### DIFF
--- a/go/client_test.go
+++ b/go/client_test.go
@@ -383,3 +383,27 @@ func TestGetLeavesRunningTaskAlone(t *testing.T) {
 		t.Error("a running task must not be marked complete")
 	}
 }
+
+// TestStructuredErrorIsTerminal covers the hailuo shape: success:false with an
+// error object and no finished_at. Reading it as still-running makes a caller
+// poll until timeout instead of surfacing the upstream's reason.
+func TestStructuredErrorIsTerminal(t *testing.T) {
+	state := map[string]any{
+		"response": map[string]any{
+			"success": false,
+			"error":   map[string]any{"code": "api_error", "message": "no channel"},
+		},
+	}
+	if got := taskStatus(state); got != "failed" {
+		t.Errorf("taskStatus = %q, want failed", got)
+	}
+}
+
+func TestTransientErrorKeepsWaiting(t *testing.T) {
+	state := map[string]any{
+		"response": map[string]any{"success": false, "error": "temporary"},
+	}
+	if got := taskStatus(state); got != "" {
+		t.Errorf("taskStatus = %q, want empty (still running)", got)
+	}
+}

--- a/go/tasks.go
+++ b/go/tasks.go
@@ -158,6 +158,25 @@ func taskStatus(state map[string]any) string {
 		return "" // queued, processing, … — keep waiting
 	}
 
+	// success:false alone is ambiguous — some services set it for a transient
+	// hiccup mid-run, alongside a bare string, and carry on. A structured error
+	// (a map with a code) is the upstream's final answer: hailuo reports an
+	// unavailable model that way, with no finished_at, and treating it as still
+	// running makes the caller poll until timeout instead of showing the reason.
+	if v, present := resp["success"]; present {
+		if b, isBool := v.(bool); isBool && !b {
+			structured := false
+			if e, ok := resp["error"].(map[string]any); ok {
+				if code, has := e["code"]; has && code != nil {
+					structured = true
+				}
+			}
+			if structured || len(ArtifactURLs(state)) > 0 {
+				return "failed"
+			}
+		}
+	}
+
 	_, finishedInResp := resp["finished_at"]
 	_, finishedInState := state["finished_at"]
 	if finishedInResp || finishedInState {

--- a/python/src/acedatacloud/_runtime/tasks.py
+++ b/python/src/acedatacloud/_runtime/tasks.py
@@ -99,13 +99,17 @@ def task_status(state: dict[str, Any]) -> str:
         # A non-terminal word (queued, processing, …) means keep waiting.
         return ""
 
-    # No status word at all. `success: false` on its own is ambiguous — some
-    # services use it for a retryable hiccup mid-run, and the task tests pin
-    # that — but paired with an artifact the job has clearly finished, and
-    # finished unsuccessfully. Without this, such a response reaches the caller
-    # as a success.
-    if response.get("success") is False and artifact_urls(state):
-        return "failed"
+    # No status word at all. `success: false` alone is ambiguous: some services
+    # set it for a transient hiccup mid-run, alongside a bare string like
+    # "temporary", and keep going. A *structured* error — a dict carrying a code
+    # — is different: that is the upstream's final answer. hailuo reports an
+    # unavailable model exactly so, with no finished_at, and reading it as
+    # "still running" makes the caller poll until timeout instead of telling the
+    # user "no channel available for this model".
+    if response.get("success") is False:
+        error = response.get("error")
+        if artifact_urls(state) or (isinstance(error, dict) and error.get("code")):
+            return "failed"
 
     finished = response.get("finished_at") is not None or state.get("finished_at") is not None
     if finished:

--- a/python/tests/test_providers.py
+++ b/python/tests/test_providers.py
@@ -221,3 +221,29 @@ def test_get_leaves_a_running_task_alone(client):
 
     assert not handle.done
     assert handle.urls() == []
+
+
+def test_a_structured_error_is_terminal_even_without_finished_at():
+    """hailuo answers an unavailable-model request with success:false plus an
+    error object and no finished_at. Reading that as "still running" makes the
+    caller poll until timeout instead of showing the upstream's own reason."""
+    from acedatacloud._runtime.tasks import task_status
+
+    state = {
+        "response": {
+            "success": False,
+            "error": {"code": "api_error", "message": "no channel available for minimax-t2v"},
+            "task_id": "x",
+        },
+        "finished_at": None,
+    }
+    assert task_status(state) == "failed"
+
+
+def test_a_transient_string_error_still_keeps_waiting():
+    """Some services set success:false mid-run with a bare string and carry on.
+    Only a structured error — a dict with a code — is the upstream's last word."""
+    from acedatacloud._runtime.tasks import task_status
+
+    assert task_status({"response": {"success": False, "error": "temporary"}}) == ""
+    assert task_status({"response": {"success": False, "error": None}}) == ""

--- a/typescript/src/runtime/tasks.ts
+++ b/typescript/src/runtime/tasks.ts
@@ -137,6 +137,17 @@ export function taskStatus(state: Record<string, unknown>): 'succeeded' | 'faile
   }
   if (words.length > 0) return '';
 
+  // `success: false` alone is ambiguous — some services set it for a transient
+  // hiccup mid-run, alongside a bare string, and carry on. A *structured* error
+  // (a dict with a code) is the upstream's final answer: hailuo reports an
+  // unavailable model that way, with no finished_at, and treating it as still
+  // running makes the caller poll until timeout instead of showing the reason.
+  if (response.success === false) {
+    const error = response.error as Record<string, unknown> | undefined;
+    const structured = !!error && typeof error === 'object' && !!error.code;
+    if (artifactUrls(state).length > 0 || structured) return 'failed';
+  }
+
   const finished =
     (response.finished_at !== undefined && response.finished_at !== null) ||
     (state.finished_at !== undefined && state.finished_at !== null);

--- a/typescript/tests/tasks.test.ts
+++ b/typescript/tests/tasks.test.ts
@@ -1,4 +1,4 @@
-import { TaskHandle } from '../src/runtime/tasks';
+import { TaskHandle, taskStatus } from '../src/runtime/tasks';
 
 describe('TaskHandle', () => {
   it('waits through accepted responses and completes on success data without status', async () => {
@@ -99,5 +99,24 @@ describe('get() records a terminal state', () => {
     await handle.wait();
 
     expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('success:false without finished_at', () => {
+  // hailuo answers an unavailable-model request this way. Treating it as still
+  // running makes a caller poll until timeout instead of showing the reason.
+  it('is terminal when the error is structured', () => {
+    const state = {
+      response: {
+        success: false,
+        error: { code: 'api_error', message: 'no channel available for minimax-t2v' },
+      },
+    };
+    expect(taskStatus(state)).toBe('failed');
+  });
+
+  it('keeps waiting on a bare string error', () => {
+    expect(taskStatus({ response: { success: false, error: 'temporary' } })).toBe('');
+    expect(taskStatus({ response: { success: false, error: null } })).toBe('');
   });
 });


### PR DESCRIPTION
## 现象

hailuo 请求一个不可用的模型，返回：

```json
{
  "success": false,
  "error": {
    "code": "api_error",
    "message": "当前分组 default 下对于模型 minimax-t2v 无可用渠道"
  }
}
```

**没有 `finished_at`，也没有产物。**

`task_status` 把它读成「还在跑」，于是调用方轮询了 9 分钟然后报超时 —— 而上游第一次响应就给了明确原因。

## 修复的关键：区分两种 `success: false`

仓库原有测试钉住了一个真实语义：某些服务在**运行中**用 `success:false` + 一个裸字符串表示瞬时抖动，然后继续跑。不能一刀切。

区分点是 **`error` 的形态**：

| error | 含义 | 判定 |
|---|---|---|
| `{"code": "api_error", ...}` 对象 | 上游的最终答复 | **failed** |
| `"temporary"` 字符串 | 运行中的提示 | 继续等 |

## TS 和 Go 漂移得更远

它们**连 Python 原有的「success:false + 有产物 = 失败」都没有**。三语言现已一致。

## 怎么发现的

不是靠测试，是**盯着真实的 hailuo 轮询响应看** —— 停在「超时」这个表象上就永远查不到。

159 个 Python 测试通过，Go 构建和测试通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)