### PR TITLE
feat(seedance): generate Seedance 2.5 SDK support

### DIFF
--- a/go/provider_seedance.go
+++ b/go/provider_seedance.go
@@ -13,30 +13,36 @@ type Seedance struct {
 
 // SeedanceGenerateRequest is the input to seedance.Generate.
 type SeedanceGenerateRequest struct {
-	// Model ID for video generation
+	// $t(seedance_videos_model)
 	Model string
-	// Input content for video generation. Each entry must include one of `text`, `image_url`, `audio_url`, or `video
+	// $t(seedance_videos)
 	Content []any
-	// The random seed used for reproducible generation has a value range from -1 to 4294967295; -1 indicates randomn
-	Seed int
-	// Aspect ratio of the generated video
-	Ratio string
-	// The frame count for generating a video must meet 25 + 4n (such as 29, 33, 37... 361). Either duration or frame
-	Frames int
-	// The duration of the generated video, in seconds. Either duration or frames can be specified; if both are speci
-	Duration int
-	// Whether to add a watermark to the generated video.
-	Watermark bool
-	// Video resolution. The default value depends on the model used: most models default to 720p, while the lite mod
+	// $t(seedance_videos_resolution)
 	Resolution string
-	// Is the camera position fixed during the generation process?
+	// $t(seedance_videos_ratio)
+	Ratio string
+	// $t(seedance_videos_duration)
+	Duration int
+	// $t(seedance_videos_frames)
+	Frames int
+	// $t(seedance_videos_seed)
+	Seed int
+	// $t(seedance_videos_camerafixed)
 	Camerafixed bool
-	// Whether to generate audio from video. The `doubao-seedance-1-5-pro-251215` and `doubao-seedance-2-0` series mo
+	// $t(seedance_videos_watermark)
+	Watermark bool
+	// $t(seedance_videos_generate_audio)
 	GenerateAudio bool
-	// Whether to return the last frame of the generated video.
+	// $t(seedance_videos_return_last_frame)
 	ReturnLastFrame bool
-	// Task timeout threshold, unit in seconds
+	// $t(seedance_videos_execution_expires_after)
 	ExecutionExpiresAfter int
+	// $t(seedance_videos_omni_reference_task_type)
+	OmniReferenceTaskType string
+	// $t(seedance_videos_output_format)
+	OutputFormat string
+	// $t(seedance_videos_tools)
+	Tools []map[string]any
 	// Async submits without blocking; poll the returned handle. Defaults true.
 	Async *bool
 	// CallbackURL optionally receives the completion webhook.
@@ -49,31 +55,40 @@ func (r SeedanceGenerateRequest) toBody() map[string]any {
 	body := map[string]any{}
 	body["model"] = r.Model
 	body["content"] = r.Content
-	if r.Seed != 0 {
-		body["seed"] = r.Seed
+	if r.Resolution != "" {
+		body["resolution"] = r.Resolution
 	}
 	if r.Ratio != "" {
 		body["ratio"] = r.Ratio
 	} else {
 		body["ratio"] = "16:9"
 	}
-	if r.Frames != 0 {
-		body["frames"] = r.Frames
-	}
 	if r.Duration != 0 {
 		body["duration"] = r.Duration
 	}
-	body["watermark"] = r.Watermark
-	if r.Resolution != "" {
-		body["resolution"] = r.Resolution
+	if r.Frames != 0 {
+		body["frames"] = r.Frames
+	}
+	if r.Seed != 0 {
+		body["seed"] = r.Seed
 	}
 	body["camerafixed"] = r.Camerafixed
+	body["watermark"] = r.Watermark
 	body["generate_audio"] = r.GenerateAudio
 	body["return_last_frame"] = r.ReturnLastFrame
 	if r.ExecutionExpiresAfter != 0 {
 		body["execution_expires_after"] = r.ExecutionExpiresAfter
 	} else {
 		body["execution_expires_after"] = 172800
+	}
+	if r.OmniReferenceTaskType != "" {
+		body["omni_reference_task_type"] = r.OmniReferenceTaskType
+	}
+	if r.OutputFormat != "" {
+		body["output_format"] = r.OutputFormat
+	}
+	if r.Tools != nil {
+		body["tools"] = r.Tools
 	}
 	body["async"] = true
 	if r.Async != nil {
@@ -90,7 +105,7 @@ func (r SeedanceGenerateRequest) toBody() map[string]any {
 	return body
 }
 
-// Generate ByteDance Seedance video generation API. Supports doubao-seedance-1-0-pro-250528, doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-5-pro-251215,
+// Generate Call /seedance/videos.
 func (c *Seedance) Generate(ctx context.Context, req SeedanceGenerateRequest) (*TaskHandle, error) {
 	result, err := c.t.do(ctx, requestOpts{
 		Method: "POST",

--- a/go/provider_seedance_test.go
+++ b/go/provider_seedance_test.go
@@ -1,0 +1,32 @@
+package acedatacloud
+
+import "testing"
+
+func TestSeedance25RequestUsesPublicFields(t *testing.T) {
+	req := SeedanceGenerateRequest{
+		Model:                 "doubao-seedance-2-5-260628",
+		Content:               []any{map[string]any{"type": "text", "text": "Extend the scene"}},
+		Duration:              30,
+		Camerafixed:           true,
+		OmniReferenceTaskType: "extend",
+		OutputFormat:          "mov",
+		Tools:                 []map[string]any{{"type": "web_search"}},
+	}
+	body := req.toBody()
+	if body["model"] != req.Model || body["omni_reference_task_type"] != "extend" || body["output_format"] != "mov" {
+		t.Fatalf("unexpected Seedance 2.5 body: %#v", body)
+	}
+	if body["camerafixed"] != true || body["camera_fixed"] != nil {
+		t.Fatalf("camera field drift: %#v", body)
+	}
+}
+
+func TestSeedance20OmitsSeedance25Defaults(t *testing.T) {
+	body := (SeedanceGenerateRequest{
+		Model:   "doubao-seedance-2-0-260128",
+		Content: []any{map[string]any{"type": "text", "text": "A scene"}},
+	}).toBody()
+	if _, exists := body["output_format"]; exists {
+		t.Fatalf("2.0 request unexpectedly contains output_format: %#v", body)
+	}
+}

--- a/python/src/acedatacloud/resources/providers/seedance.py
+++ b/python/src/acedatacloud/resources/providers/seedance.py
@@ -20,6 +20,7 @@ SeedanceModel = Literal[
     "doubao-seedance-2-0-260128",
     "doubao-seedance-2-0-fast-260128",
     "doubao-seedance-2-0-mini-260615",
+    "doubao-seedance-2-5-260628",
 ]
 SeedanceRatio = Literal[
     "16:9",
@@ -55,16 +56,19 @@ class Seedance:
         *,
         model: SeedanceModel,
         content: list[Any],
-        seed: int | None = None,
-        ratio: SeedanceRatio | None = None,
-        frames: int | None = None,
-        duration: int | None = None,
-        watermark: bool | None = None,
         resolution: Literal["480p", "720p", "1080p", "4k"] | None = None,
+        ratio: SeedanceRatio | None = None,
+        duration: int | None = None,
+        frames: int | None = None,
+        seed: int | None = None,
         camerafixed: bool | None = None,
+        watermark: bool | None = None,
         generate_audio: bool | None = None,
         return_last_frame: bool | None = None,
         execution_expires_after: int | None = None,
+        omni_reference_task_type: Literal["auto", "edit", "extend"] | None = None,
+        output_format: Literal["mp4", "mov"] | None = None,
+        tools: list[dict[str, Any]] | None = None,
         async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 3.0,
@@ -72,29 +76,32 @@ class Seedance:
         callback_url: str | None = None,
         **extra: Any,
     ) -> TaskHandle:
-        """ByteDance Seedance video generation API. Supports doubao-seedance-1-0-pro-250528,
-        doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-lite-t2v-250428,
-        and doubao-s
-        """
+        """Call /seedance/videos."""
         body: dict[str, Any] = {}
         body["model"] = model
         body["content"] = content
-        if seed is not None:
-            body["seed"] = seed
-        body["ratio"] = ratio if ratio is not None else "16:9"
-        if frames is not None:
-            body["frames"] = frames
-        if duration is not None:
-            body["duration"] = duration
-        if watermark is not None:
-            body["watermark"] = watermark
         if resolution is not None:
             body["resolution"] = resolution
+        body["ratio"] = ratio if ratio is not None else "16:9"
+        if duration is not None:
+            body["duration"] = duration
+        if frames is not None:
+            body["frames"] = frames
+        if seed is not None:
+            body["seed"] = seed
         if camerafixed is not None:
             body["camerafixed"] = camerafixed
+        if watermark is not None:
+            body["watermark"] = watermark
         body["generate_audio"] = generate_audio if generate_audio is not None else False
         body["return_last_frame"] = return_last_frame if return_last_frame is not None else False
         body["execution_expires_after"] = execution_expires_after if execution_expires_after is not None else 172800
+        if omni_reference_task_type is not None:
+            body["omni_reference_task_type"] = omni_reference_task_type
+        if output_format is not None:
+            body["output_format"] = output_format
+        if tools is not None:
+            body["tools"] = tools
         body.update(extra)
         if callback_url is not None:
             body["callback_url"] = callback_url
@@ -117,16 +124,19 @@ class AsyncSeedance:
         *,
         model: SeedanceModel,
         content: list[Any],
-        seed: int | None = None,
-        ratio: SeedanceRatio | None = None,
-        frames: int | None = None,
-        duration: int | None = None,
-        watermark: bool | None = None,
         resolution: Literal["480p", "720p", "1080p", "4k"] | None = None,
+        ratio: SeedanceRatio | None = None,
+        duration: int | None = None,
+        frames: int | None = None,
+        seed: int | None = None,
         camerafixed: bool | None = None,
+        watermark: bool | None = None,
         generate_audio: bool | None = None,
         return_last_frame: bool | None = None,
         execution_expires_after: int | None = None,
+        omni_reference_task_type: Literal["auto", "edit", "extend"] | None = None,
+        output_format: Literal["mp4", "mov"] | None = None,
+        tools: list[dict[str, Any]] | None = None,
         async_: bool | None = None,
         wait: bool = False,
         poll_interval: float = 3.0,
@@ -134,29 +144,32 @@ class AsyncSeedance:
         callback_url: str | None = None,
         **extra: Any,
     ) -> AsyncTaskHandle:
-        """ByteDance Seedance video generation API. Supports doubao-seedance-1-0-pro-250528,
-        doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-lite-t2v-250428,
-        and doubao-s
-        """
+        """Call /seedance/videos."""
         body: dict[str, Any] = {}
         body["model"] = model
         body["content"] = content
-        if seed is not None:
-            body["seed"] = seed
-        body["ratio"] = ratio if ratio is not None else "16:9"
-        if frames is not None:
-            body["frames"] = frames
-        if duration is not None:
-            body["duration"] = duration
-        if watermark is not None:
-            body["watermark"] = watermark
         if resolution is not None:
             body["resolution"] = resolution
+        body["ratio"] = ratio if ratio is not None else "16:9"
+        if duration is not None:
+            body["duration"] = duration
+        if frames is not None:
+            body["frames"] = frames
+        if seed is not None:
+            body["seed"] = seed
         if camerafixed is not None:
             body["camerafixed"] = camerafixed
+        if watermark is not None:
+            body["watermark"] = watermark
         body["generate_audio"] = generate_audio if generate_audio is not None else False
         body["return_last_frame"] = return_last_frame if return_last_frame is not None else False
         body["execution_expires_after"] = execution_expires_after if execution_expires_after is not None else 172800
+        if omni_reference_task_type is not None:
+            body["omni_reference_task_type"] = omni_reference_task_type
+        if output_format is not None:
+            body["output_format"] = output_format
+        if tools is not None:
+            body["tools"] = tools
         body.update(extra)
         if callback_url is not None:
             body["callback_url"] = callback_url

--- a/python/tests/test_providers.py
+++ b/python/tests/test_providers.py
@@ -100,6 +100,41 @@ def test_caller_value_beats_the_spec_default(client):
     assert transport.request.call_args.kwargs["json"]["size"] == "512x512"
 
 
+def test_seedance_25_serializes_public_contract(client):
+    transport = Mock()
+    transport.request.return_value = {"task_id": "seedance-25"}
+    client.seedance._transport = transport
+
+    client.seedance.generate(
+        model="doubao-seedance-2-5-260628",
+        content=[{"type": "text", "text": "Extend the scene"}],
+        duration=30,
+        camerafixed=True,
+        omni_reference_task_type="extend",
+        output_format="mov",
+        tools=[{"type": "web_search"}],
+    )
+
+    body = transport.request.call_args.kwargs["json"]
+    assert body["model"] == "doubao-seedance-2-5-260628"
+    assert body["omni_reference_task_type"] == "extend"
+    assert body["output_format"] == "mov"
+    assert body["tools"] == [{"type": "web_search"}]
+    assert body["camerafixed"] is True
+    assert "camera_fixed" not in body
+
+
+def test_seedance_20_does_not_receive_25_defaults(client):
+    transport = Mock()
+    transport.request.return_value = {"task_id": "seedance-20"}
+    client.seedance._transport = transport
+    client.seedance.generate(
+        model="doubao-seedance-2-0-260128",
+        content=[{"type": "text", "text": "A scene"}],
+    )
+    assert "output_format" not in transport.request.call_args.kwargs["json"]
+
+
 def test_seedream_omits_example_only_size(client):
     transport = Mock()
     transport.request.return_value = {

--- a/scripts/specs/0083b874-4da6-40df-87e3-835b1300c1e8.json
+++ b/scripts/specs/0083b874-4da6-40df-87e3-835b1300c1e8.json
@@ -1,1 +1,1013 @@
-{"paths": {"/seedance/videos": {"post": {"summary": "ByteDance Seedance video generation API. Supports doubao-seedance-1-0-pro-250528, doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-lite-t2v-250428, and doubao-seedance-1-0-lite-i2v-250428, covering text-to-video, image-to-video, multiple resolutions / durations, and optional synced audio.", "security": [{"bearerAuth": []}], "responses": {"200": {"content": {"application/json": {"schema": {"type": "object", "example": {"data": [{"id": "cgt-2025******-***", "seed": 10, "model": "doubao-seedance-1-0-pro-250528", "ratio": "16:9", "usage": {"total_tokens": 108900, "completion_tokens": 108900}, "status": "succeeded", "content": {"video_url": "https://ark-content-generation-cn-beijing.tos-cn-beijing.volces.com/doubao-seedance-1-0-pro/****"}, "duration": 5, "created_at": 1743414619, "resolution": "720p", "updated_at": 1743414673, "framespersecond": 24, "execution_expires_after": 172800}], "success": true, "task_id": "93f11baf-347b-4bb4-9520-8653cb46d6a3", "trace_id": "a9063166-26ed-4451-85b5-54e896817c69"}, "properties": {"data": {"type": "array", "items": {"type": "object", "properties": {"id": {"type": "string", "description": "The unique ID of this result"}, "seed": {"type": "integer", "description": "Random seed used during generation"}, "model": {"type": "string", "description": "Model used for generation"}, "ratio": {"type": "string", "description": "Aspect ratio of the video"}, "usage": {"type": "object", "properties": {"total_tokens": {"type": "integer", "description": "The total number of tokens consumed by this request."}, "completion_tokens": {"type": "integer", "description": "The number of tokens consumed by generated content"}}, "description": "Resource usage information for this request"}, "status": {"type": "string", "description": "Generate status, for example, `succeeded` indicates successful generation."}, "content": {"type": "object", "properties": {"video_url": {"type": "string", "description": "The URL of the generated video file, if not available, is an empty string."}}, "description": "Detailed information about the generated content"}, "duration": {"type": "integer", "description": "Duration, measured in seconds"}, "created_at": {"type": "integer", "description": "The creation time of this result"}, "resolution": {"type": "string", "description": "Video resolution"}, "updated_at": {"type": "integer", "description": "The most recent update time of this result."}, "framespersecond": {"type": "integer", "description": "Frame rate of the video (frames per second)"}, "execution_expires_after": {"type": "integer", "description": "The expiration time of the task execution result, in seconds."}}}, "description": "Generate or edit a list of video entries based on the prompts."}, "success": {"type": "boolean", "description": "Flag indicating whether this request was successful."}, "task_id": {"type": "string", "description": "The task ID for this request"}, "trace_id": {"type": "string", "description": "The tracking ID for this request"}}}, "properties": {"data": {"type": "object", "description": "Generate or edit a list of video entries based on the prompts."}, "success": {"type": "boolean", "description": "Flag indicating whether this request was successful."}, "task_id": {"type": "string", "description": "The task ID for this request"}, "trace_id": {"type": "string", "description": "The tracking ID for this request"}}}}, "description": "Request successful (OK)."}, "400": {"content": {"application/json": {"schema": {"oneOf": [{"type": "object", "example": {"error": {"code": "token_mismatched", "message": "The specified token is not matched with API."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "token_mismatched", "description": "Response error code."}, "message": {"type": "string", "example": "The specified token is not matched with API.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}, {"type": "object", "example": {"error": {"code": "api_not_implemented", "message": "The API is not implemented."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "api_not_implemented", "description": "Response error code."}, "message": {"type": "string", "example": "The API is not implemented.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}, {"type": "object", "example": {"error": {"code": "disabled", "message": "Your application has been disabled by Ace Data Cloud due to abnormal usage behavior, please contact our support to get more information."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "disabled", "description": "Response error code."}, "message": {"type": "string", "example": "Your application has been disabled by Ace Data Cloud due to abnormal usage behavior, please contact our support to get more information.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}, {"type": "object", "example": {"error": {"code": "bad_request", "message": "model is invalid."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "bad_request", "description": "Response error code."}, "message": {"type": "string", "example": "model is invalid.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}, {"type": "object", "example": {"error": {"code": "no_token", "message": "No token specified for the request."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "no_token", "description": "Response error code."}, "message": {"type": "string", "example": "No token specified for the request.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}]}}}, "description": "Request error, possibly due to missing or invalid parameters."}, "401": {"content": {"application/json": {"schema": {"oneOf": [{"type": "object", "example": {"error": {"code": "invalid_token", "message": "The specified token is invalid or wrong."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "invalid_token", "description": "Response error code."}, "message": {"type": "string", "example": "The specified token is invalid or wrong.", "description": "Response error message."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}, {"type": "object", "example": {"error": {"code": "token_expired", "message": "token expired."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "token_expired", "description": "Response error code."}, "message": {"type": "string", "example": "token expired.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}, {"type": "object", "example": {"error": {"code": "token_mismatched", "message": "token and api does not match."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "token_mismatched", "description": "Response error code."}, "message": {"type": "string", "example": "token and api does not match.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}]}}}, "description": "Unauthorized, authorization token is invalid or missing."}, "403": {"content": {"application/json": {"schema": {"oneOf": [{"type": "object", "example": {"error": {"code": "used_up", "message": "Your balance is not sufficient for current request, please buy more in Ace Data Cloud."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "used_up", "description": "Response error code."}, "message": {"type": "string", "example": "Your balance is not sufficient for current request, please buy more in Ace Data Cloud.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}]}}}, "description": "Unauthorized, authorization token is invalid or missing."}, "404": {"content": {"application/json": {"schema": {"oneOf": [{"type": "object", "example": {"error": {"code": "no_api", "message": "API does not exist, please make sure url is correct."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "no_api", "description": "Response error code."}, "message": {"type": "string", "example": "API does not exist, please make sure url is correct.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}]}}}, "description": "Unauthorized, authorization token is invalid or missing."}, "413": {"content": {"application/json": {"schema": {"oneOf": [{"type": "object", "example": {"error": {"code": "request_too_large", "message": "Request body is too large."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "request_too_large", "description": "Response error code."}, "message": {"type": "string", "example": "Request body is too large.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}]}}}, "description": "Unauthorized, authorization token is invalid or missing."}, "429": {"content": {"application/json": {"schema": {"oneOf": [{"type": "object", "example": {"error": {"code": "too_many_requests", "message": "You have exceeded the rate limit."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "too_many_requests", "description": "Response error code."}, "message": {"type": "string", "example": "You have exceeded the rate limit.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}]}}}, "description": "Too many requests, rate limit exceeded."}, "500": {"content": {"application/json": {"schema": {"oneOf": [{"type": "object", "example": {"error": {"code": "api_error", "message": "Internal server error."}, "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"}, "properties": {"error": {"type": "object", "properties": {"code": {"type": "string", "example": "api_error", "description": "Response error code."}, "message": {"type": "string", "example": "Internal server error.", "description": "Error message of the response."}}}, "trace_id": {"type": "string", "description": "The tracking ID for this request."}}}]}}}, "description": "Internal server error, an exception occurred on the server side."}}, "parameters": [{"in": "header", "name": "accept", "schema": {"enum": ["application/json"], "type": "string"}, "required": false, "description": "Specify the format of the server response. If not specified, the default format is `application/json`."}], "requestBody": {"content": {"application/json": {"schema": {"type": "object", "required": ["model", "content"], "properties": {"seed": {"type": "integer", "maximum": 4294967295, "minimum": -1, "description": "The random seed used for reproducible generation has a value range from -1 to 4294967295; -1 indicates randomness."}, "async": {"rank": 101, "type": "boolean", "description": "Whether to process in asynchronous mode. When set to `true`, the interface immediately returns `task_id`, without the need to provide `callback_url`, and then the result can be obtained by polling the corresponding task query interface; if `callback_url` is also provided, the result will be pushed to that callback address."}, "model": {"enum": ["doubao-seedance-1-0-pro-250528", "doubao-seedance-1-0-pro-fast-251015", "doubao-seedance-1-5-pro-251215", "doubao-seedance-1-0-lite-t2v-250428", "doubao-seedance-1-0-lite-i2v-250428", "doubao-seedance-2-0-260128", "doubao-seedance-2-0-fast-260128", "doubao-seedance-2-0-mini-260615"], "type": "string", "example": "doubao-seedance-1-0-pro-250528", "description": "Model ID for video generation"}, "ratio": {"enum": ["16:9", "4:3", "1:1", "3:4", "9:16", "21:9", "adaptive"], "type": "string", "default": "16:9", "description": "Aspect ratio of the generated video"}, "frames": {"type": "integer", "maximum": 361, "minimum": 29, "description": "The frame count for generating a video must meet 25 + 4n (such as 29, 33, 37... 361). Either duration or frames can be specified; if both are specified, frames take priority over duration."}, "content": {"type": "array", "items": {"oneOf": [{"type": "object", "example": {"text": "A kitten yawning at the camera. --rs 720p --rt 16:9 --dur 5 --fps 24 --wm true --seed 11 --cf false", "type": "text"}, "required": ["type", "text"], "properties": {"text": {"type": "string", "example": "A kitten yawning at the camera. --rs 720p --rt 16:9 --dur 5 --fps 24 --wm true --seed 11 --cf false", "maxLength": 1000, "description": "Describe the text content expected to generate the video. You can use the old `--param value` syntax at the end of the prompt to add inline parameters (weak validation, invalid values will silently use default values). Supported inline parameters: `--rs` (resolution: 480p/720p/1080p), `--rt` (aspect ratio: 16:9/4:3/1:1/3:4/9:16/21:9/adaptive), `--dur` (duration, in seconds: Seedance 1.0 Pro/Pro Fast is 2-12; Seedance 1.5 Pro is 4-12 or -1; Seedance 2.0 series is 4-15 or -1, -1 means automatic), `--frames` (number of frames: an integer satisfying 25+4n, range [29,361]), `--fps` (frame rate: only supports 24), `--seed` (random seed: -1 to 4294967295), `--cf` (fixed shot: true/false), `--wm` (watermark: true/false). For strong validation, please use the top-level parameters in the request body."}, "type": {"enum": ["text"], "type": "string", "description": "Content type discrimination field."}}, "additionalProperties": false}, {"type": "object", "example": {"role": "first_frame", "type": "image_url", "image_url": {"url": "https://cdn.acedata.cloud/v8073y.png"}}, "required": ["type", "image_url"], "properties": {"role": {"enum": ["first_frame", "last_frame", "reference_image"], "type": "string", "description": "Optional. The position or use of the image. The three scenarios of first frame (first_frame), combination of first and last frame (last_frame), and reference image (reference_image) are mutually exclusive and cannot be used together."}, "type": {"enum": ["image_url"], "type": "string", "description": "Content type discrimination field."}, "image_url": {"type": "object", "required": ["url"], "properties": {"url": {"type": "string", "example": "https://cdn.acedata.cloud/v8073y.png", "description": "Image URL or Base64 encoded image (format: data:image/<format>;base64,<data>). The image size must be at least 300\u00d7300 pixels."}}, "description": "Image object. It must be an object that contains a `url` property, and the value of `url` should be an image URL or Base64 data.", "additionalProperties": false}}, "additionalProperties": false}, {"type": "object", "example": {"role": "reference_audio", "type": "audio_url", "audio_url": {"url": "https://cdn.acedata.cloud/suno_demo.mp3"}}, "required": ["type", "audio_url"], "properties": {"role": {"enum": ["reference_audio"], "type": "string", "description": "Optional. Audio usage, currently supports reference_audio."}, "type": {"enum": ["audio_url"], "type": "string", "description": "Content type discrimination field."}, "audio_url": {"type": "object", "required": ["url"], "properties": {"url": {"type": "string", "example": "https://cdn.acedata.cloud/suno_demo.mp3", "description": "Audio URL. The Seedance 2.0 series supports reference audio for generating voiced videos or reference human voice tones, background music, and other audio information."}}, "description": "Audio object. It must be an object that contains a `url` property, and the value of `url` must be a publicly accessible audio URL.", "additionalProperties": false}}, "additionalProperties": false}, {"type": "object", "example": {"role": "reference_video", "type": "video_url", "video_url": {"url": "https://cdn.acedata.cloud/43a57990c0.mp4"}}, "required": ["type", "video_url"], "properties": {"role": {"enum": ["reference_video"], "type": "string", "description": "Optional. Video usage, currently supports reference_video."}, "type": {"enum": ["video_url"], "type": "string", "description": "Content type discrimination field."}, "video_url": {"type": "object", "required": ["url"], "properties": {"url": {"type": "string", "example": "https://cdn.acedata.cloud/43a57990c0.mp4", "description": "Video URL. The Seedance 2.0 series supports reference videos for referencing main content, camera movement, action performance, or overall style."}}, "description": "Video object. It must be an object that contains a `url` property, and the value of `url` must be a publicly accessible video URL.", "additionalProperties": false}}, "additionalProperties": false}], "discriminator": {"propertyName": "type"}}, "description": "Input content for video generation. Each entry must include one of `text`, `image_url`, `audio_url`, or `video_url` corresponding to the `type`. The meaning of other fields and whether they are required depends on the value of `type`."}, "duration": {"type": "integer", "maximum": 15, "minimum": -1, "description": "The duration of the generated video, in seconds. Either duration or frames can be specified; if both are specified, frames take priority over duration. The duration range varies for each model: Seedance 2.0 series is 4 to 15 seconds or -1, Seedance 1.5 Pro is 4 to 12 seconds or -1, and Seedance 1.0 series is 2 to 12 seconds. -1 indicates automatic duration."}, "watermark": {"type": "boolean", "description": "Whether to add a watermark to the generated video."}, "resolution": {"enum": ["480p", "720p", "1080p", "4k"], "type": "string", "description": "Video resolution. The default value depends on the model used: most models default to 720p, while the lite model defaults to 480p. Note that the supported resolutions vary by model: `4k` is only supported by doubao-seedance-2-0 (standard version); doubao-seedance-2-0-fast and doubao-seedance-2-0-mini do not support 1080p and 4k."}, "camerafixed": {"type": "boolean", "description": "Is the camera position fixed during the generation process?"}, "callback_url": {"type": "string", "format": "uri", "description": "Callback URL for receiving the final result notification of the task. Once provided, the API will immediately return `task_id` and push the results to that URL when the task is completed."}, "generate_audio": {"type": "boolean", "default": false, "description": "Whether to generate audio from video. The `doubao-seedance-1-5-pro-251215` and `doubao-seedance-2-0` series models support this parameter, while other models will ignore this parameter."}, "return_last_frame": {"type": "boolean", "default": false, "description": "Whether to return the last frame of the generated video."}, "execution_expires_after": {"type": "integer", "default": 172800, "maximum": 259200, "minimum": 3600, "description": "Task timeout threshold, unit in seconds"}}}, "required": true}}}}}}, "openapi": "3.0.0", "servers": [{"url": "https://api.acedata.cloud", "description": "Ace Data Cloud API Server"}], "components": {"securitySchemes": {"bearerAuth": {"type": "http", "scheme": "bearer"}}}}
+{
+  "paths": {
+    "/seedance/videos": {
+      "post": {
+        "summary": "$t(api_description_seedance_videos)",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "success": true,
+                    "task_id": "93f11baf-347b-4bb4-9520-8653cb46d6a3",
+                    "trace_id": "a9063166-26ed-4451-85b5-54e896817c69",
+                    "data": {
+                      "id": "cgt-2025******-***",
+                      "model": "doubao-seedance-1-0-pro-250528",
+                      "status": "succeeded",
+                      "content": {
+                        "video_url": "https://platform2.cdn.acedata.cloud/gemini/04a043bd-6b23-4b4e-945c-ce48158c3eee.mp4"
+                      },
+                      "seed": 10,
+                      "resolution": "720p",
+                      "ratio": "16:9",
+                      "duration": 5,
+                      "framespersecond": 24,
+                      "execution_expires_after": 172800,
+                      "usage": {
+                        "completion_tokens": 108900,
+                        "total_tokens": 108900
+                      },
+                      "created_at": 1743414619,
+                      "updated_at": 1743414673
+                    }
+                  },
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "$t(seedance_videos_response_200_success)"
+                    },
+                    "task_id": {
+                      "type": "string",
+                      "description": "$t(seedance_videos_response_200_task_id)"
+                    },
+                    "trace_id": {
+                      "type": "string",
+                      "description": "$t(seedance_videos_response_200_trace_id)"
+                    },
+                    "data": {
+                      "type": "object",
+                      "description": "$t(seedance_videos_response_200_data)",
+                      "additionalProperties": true
+                    }
+                  }
+                },
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "description": "$t(seedance_videos_response_200_data)",
+                    "additionalProperties": true
+                  },
+                  "success": {
+                    "type": "boolean",
+                    "description": "$t(seedance_videos_response_200_success)"
+                  },
+                  "task_id": {
+                    "type": "string",
+                    "description": "$t(seedance_videos_response_200_task_id)"
+                  },
+                  "trace_id": {
+                    "type": "string",
+                    "description": "$t(seedance_videos_response_200_trace_id)"
+                  }
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_200)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "token_mismatched",
+                          "message": "The specified token is not matched with API."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "token_mismatched",
+                              "description": "$t(seedance_videos_response_400_error_code)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "The specified token is not matched with API.",
+                              "description": "$t(seedance_videos_response_400_error_message)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_400_trace_id)"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "api_not_implemented",
+                          "message": "The API is not implemented."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "api_not_implemented",
+                              "description": "$t(seedance_videos_response_400_error_code_2)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "The API is not implemented.",
+                              "description": "$t(seedance_videos_response_400_error_message_2)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_400_trace_id_2)"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "disabled",
+                          "message": "Your application has been disabled by Ace Data Cloud due to abnormal usage behavior, please contact our support to get more information."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "disabled",
+                              "description": "$t(seedance_videos_response_400_error_code_3)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Your application has been disabled by Ace Data Cloud due to abnormal usage behavior, please contact our support to get more information.",
+                              "description": "$t(seedance_videos_response_400_error_message_3)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_400_trace_id_3)"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "bad_request",
+                          "message": "model is invalid."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "bad_request",
+                              "description": "$t(seedance_videos_response_400_error_code_4)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "model is invalid.",
+                              "description": "$t(seedance_videos_response_400_error_message_4)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_400_trace_id_4)"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "no_token",
+                          "message": "No token specified for the request."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "no_token",
+                              "description": "$t(seedance_videos_response_400_error_code_5)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "No token specified for the request.",
+                              "description": "$t(seedance_videos_response_400_error_message_5)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_400_trace_id_5)"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_400)"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "invalid_token",
+                          "message": "The specified token is invalid or wrong."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "invalid_token",
+                              "description": "$t(seedance_videos_response_401_error_code)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "The specified token is invalid or wrong.",
+                              "description": "$t(seedance_videos_response_401_error_message)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_401_trace_id)"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "token_expired",
+                          "message": "token expired."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "token_expired",
+                              "description": "$t(seedance_videos_response_401_error_code_2)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "token expired.",
+                              "description": "$t(seedance_videos_response_401_error_message_2)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_401_trace_id_2)"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "token_mismatched",
+                          "message": "token and api does not match."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "token_mismatched",
+                              "description": "$t(seedance_videos_response_401_error_code_3)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "token and api does not match.",
+                              "description": "$t(seedance_videos_response_401_error_message_3)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_401_trace_id_3)"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_401)"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "used_up",
+                          "message": "Your balance is not sufficient for current request, please buy more in Ace Data Cloud."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "used_up",
+                              "description": "$t(seedance_videos_response_403_error_code)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Your balance is not sufficient for current request, please buy more in Ace Data Cloud.",
+                              "description": "$t(seedance_videos_response_403_error_message)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_403_trace_id)"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_403)"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "no_api",
+                          "message": "API does not exist, please make sure url is correct."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "no_api",
+                              "description": "$t(seedance_videos_response_404_error_code)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "API does not exist, please make sure url is correct.",
+                              "description": "$t(seedance_videos_response_404_error_message)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_404_trace_id)"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_404)"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "request_too_large",
+                          "message": "Request body is too large."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "request_too_large",
+                              "description": "$t(seedance_videos_response_413_error_code)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Request body is too large.",
+                              "description": "$t(seedance_videos_response_413_error_message)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_413_trace_id)"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_413)"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "too_many_requests",
+                          "message": "You have exceeded the rate limit."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "too_many_requests",
+                              "description": "$t(seedance_videos_response_429_error_code)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "You have exceeded the rate limit.",
+                              "description": "$t(seedance_videos_response_429_error_message)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_429_trace_id)"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_429)"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "example": {
+                        "error": {
+                          "code": "api_error",
+                          "message": "Internal server error."
+                        },
+                        "trace_id": "2efa9340-b21b-4e26-9e14-4aac95f343ab"
+                      },
+                      "properties": {
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                              "example": "api_error",
+                              "description": "$t(seedance_videos_response_500_error_code)"
+                            },
+                            "message": {
+                              "type": "string",
+                              "example": "Internal server error.",
+                              "description": "$t(seedance_videos_response_500_error_message)"
+                            }
+                          }
+                        },
+                        "trace_id": {
+                          "type": "string",
+                          "description": "$t(seedance_videos_response_500_trace_id)"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "$t(seedance_videos_response_500)"
+          }
+        },
+        "parameters": [
+          {
+            "in": "header",
+            "name": "accept",
+            "schema": {
+              "enum": [
+                "application/json"
+              ],
+              "type": "string"
+            },
+            "required": false,
+            "description": "$t(seedance_videos_param_accept)"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "model",
+                  "content"
+                ],
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "enum": [
+                      "doubao-seedance-1-0-pro-250528",
+                      "doubao-seedance-1-0-pro-fast-251015",
+                      "doubao-seedance-1-5-pro-251215",
+                      "doubao-seedance-1-0-lite-t2v-250428",
+                      "doubao-seedance-1-0-lite-i2v-250428",
+                      "doubao-seedance-2-0-260128",
+                      "doubao-seedance-2-0-fast-260128",
+                      "doubao-seedance-2-0-mini-260615",
+                      "doubao-seedance-2-5-260628"
+                    ],
+                    "example": "doubao-seedance-1-0-pro-250528",
+                    "description": "$t(seedance_videos_model)"
+                  },
+                  "content": {
+                    "type": "array",
+                    "description": "$t(seedance_videos)",
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "type",
+                            "text"
+                          ],
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "text"
+                              ],
+                              "description": "$t(seedance_videos_type)"
+                            },
+                            "text": {
+                              "type": "string",
+                              "maxLength": 1000,
+                              "example": "A kitten yawning at the camera. --rs 720p --rt 16:9 --dur 5 --fps 24 --wm true --seed 11 --cf false",
+                              "description": "$t(seedance_videos_text)"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "example": {
+                            "type": "text",
+                            "text": "A kitten yawning at the camera. --rs 720p --rt 16:9 --dur 5 --fps 24 --wm true --seed 11 --cf false"
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "type",
+                            "image_url"
+                          ],
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "image_url"
+                              ],
+                              "description": "$t(seedance_videos_type_2)"
+                            },
+                            "image_url": {
+                              "type": "object",
+                              "required": [
+                                "url"
+                              ],
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "example": "https://cdn.acedata.cloud/v8073y.png",
+                                  "description": "$t(seedance_videos_image_url_url)"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "description": "$t(seedance_videos_image_url)"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "first_frame",
+                                "last_frame",
+                                "reference_image"
+                              ],
+                              "description": "$t(seedance_videos_role)"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "example": {
+                            "type": "image_url",
+                            "role": "first_frame",
+                            "image_url": {
+                              "url": "https://cdn.acedata.cloud/v8073y.png"
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "type",
+                            "audio_url"
+                          ],
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "audio_url"
+                              ],
+                              "description": "$t(seedance_videos_type_3)"
+                            },
+                            "audio_url": {
+                              "type": "object",
+                              "required": [
+                                "url"
+                              ],
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "example": "https://cdn.acedata.cloud/suno_demo.mp3",
+                                  "description": "$t(seedance_videos_audio_url_url)"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "description": "$t(seedance_videos_audio_url)"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "reference_audio"
+                              ],
+                              "description": "$t(seedance_videos_audio_role)"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "example": {
+                            "type": "audio_url",
+                            "role": "reference_audio",
+                            "audio_url": {
+                              "url": "https://cdn.acedata.cloud/suno_demo.mp3"
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "type",
+                            "video_url"
+                          ],
+                          "properties": {
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "video_url"
+                              ],
+                              "description": "$t(seedance_videos_type_4)"
+                            },
+                            "video_url": {
+                              "type": "object",
+                              "required": [
+                                "url"
+                              ],
+                              "properties": {
+                                "url": {
+                                  "type": "string",
+                                  "example": "https://cdn.acedata.cloud/43a57990c0.mp4",
+                                  "description": "$t(seedance_videos_video_url_url)"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "description": "$t(seedance_videos_video_url)"
+                            },
+                            "role": {
+                              "type": "string",
+                              "enum": [
+                                "reference_video"
+                              ],
+                              "description": "$t(seedance_videos_video_role)"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "example": {
+                            "type": "video_url",
+                            "role": "reference_video",
+                            "video_url": {
+                              "url": "https://cdn.acedata.cloud/43a57990c0.mp4"
+                            }
+                          }
+                        }
+                      ],
+                      "discriminator": {
+                        "propertyName": "type"
+                      }
+                    }
+                  },
+                  "resolution": {
+                    "type": "string",
+                    "enum": [
+                      "480p",
+                      "720p",
+                      "1080p",
+                      "4k"
+                    ],
+                    "description": "$t(seedance_videos_resolution)"
+                  },
+                  "ratio": {
+                    "type": "string",
+                    "enum": [
+                      "16:9",
+                      "4:3",
+                      "1:1",
+                      "3:4",
+                      "9:16",
+                      "21:9",
+                      "adaptive"
+                    ],
+                    "default": "16:9",
+                    "description": "$t(seedance_videos_ratio)"
+                  },
+                  "duration": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 30,
+                    "description": "$t(seedance_videos_duration)"
+                  },
+                  "frames": {
+                    "type": "integer",
+                    "minimum": 29,
+                    "maximum": 289,
+                    "description": "$t(seedance_videos_frames)"
+                  },
+                  "seed": {
+                    "type": "integer",
+                    "minimum": -1,
+                    "maximum": 4294967295,
+                    "description": "$t(seedance_videos_seed)"
+                  },
+                  "camerafixed": {
+                    "type": "boolean",
+                    "description": "$t(seedance_videos_camerafixed)"
+                  },
+                  "watermark": {
+                    "type": "boolean",
+                    "description": "$t(seedance_videos_watermark)"
+                  },
+                  "generate_audio": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "$t(seedance_videos_generate_audio)"
+                  },
+                  "callback_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "$t(seedance_videos_callback_url)"
+                  },
+                  "async": {
+                    "rank": 101,
+                    "type": "boolean",
+                    "description": "$t(seedance_videos_async)"
+                  },
+                  "return_last_frame": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "$t(seedance_videos_return_last_frame)"
+                  },
+                  "execution_expires_after": {
+                    "type": "integer",
+                    "minimum": 3600,
+                    "maximum": 259200,
+                    "default": 172800,
+                    "description": "$t(seedance_videos_execution_expires_after)"
+                  },
+                  "omni_reference_task_type": {
+                    "type": "string",
+                    "enum": [
+                      "auto",
+                      "edit",
+                      "extend"
+                    ],
+                    "description": "$t(seedance_videos_omni_reference_task_type)"
+                  },
+                  "output_format": {
+                    "type": "string",
+                    "enum": [
+                      "mp4",
+                      "mov"
+                    ],
+                    "description": "$t(seedance_videos_output_format)"
+                  },
+                  "tools": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "description": "$t(seedance_videos_tools)"
+                  }
+                }
+              },
+              "required": true
+            }
+          }
+        },
+        "operationId": "createSeedanceVideos"
+      }
+    }
+  },
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "https://api.acedata.cloud",
+      "description": "$t(seedance_videos_servers)"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "translations": {
+    "seedance_videos_response_200_success": "标识本次请求是否成功的标志位",
+    "seedance_videos_response_200_task_id": "本次请求的任务 ID",
+    "seedance_videos_response_200_trace_id": "本次请求的追踪 ID",
+    "seedance_videos_response_200_data": "根据提示词生成或编辑的视频条目列表",
+    "seedance_videos_response_200_data_id": "该条结果的唯一 ID",
+    "seedance_videos_response_200_data_model": "生成所使用的模型",
+    "seedance_videos_response_200_data_status": "生成状态，例如 `succeeded` 表示生成成功",
+    "seedance_videos_response_200_data_2": "生成内容的详细信息",
+    "seedance_videos_response_200_data_video_url": "生成的视频文件的 URL，若无则为空字符串",
+    "seedance_videos_response_200_data_seed": "生成时使用的随机种子",
+    "seedance_videos_response_200_data_resolution": "视频的分辨率",
+    "seedance_videos_response_200_data_ratio": "视频的宽高比",
+    "seedance_videos_response_200_data_duration": "时长，单位为秒",
+    "seedance_videos_response_200_data_framespersecond": "视频的帧率（每秒帧数）",
+    "seedance_videos_response_200_data_execution_expires_after": "任务执行结果的过期时间，单位为秒",
+    "seedance_videos_response_200_data_usage": "本次请求的资源用量信息",
+    "seedance_videos_response_200_data_usage_completion_tokens": "生成内容消耗的 Token 数量",
+    "seedance_videos_response_200_data_usage_total_tokens": "本次请求消耗的 Token 总数",
+    "seedance_videos_response_200_data_created_at": "该条结果的创建时间",
+    "seedance_videos_response_200_data_updated_at": "该条结果的最近更新时间",
+    "seedance_videos_response_200": "请求成功（OK）。",
+    "seedance_videos_response_400_error_code": "响应的错误码。",
+    "seedance_videos_response_400_error_message": "响应的错误信息。",
+    "seedance_videos_response_400_trace_id": "本次请求的追踪 ID。",
+    "seedance_videos_response_400_error_code_2": "响应的错误码。",
+    "seedance_videos_response_400_error_message_2": "响应的错误信息。",
+    "seedance_videos_response_400_trace_id_2": "本次请求的追踪 ID。",
+    "seedance_videos_response_400_error_code_3": "响应的错误码。",
+    "seedance_videos_response_400_error_message_3": "响应的错误信息。",
+    "seedance_videos_response_400_trace_id_3": "本次请求的追踪 ID。",
+    "seedance_videos_response_400_error_code_4": "响应的错误码。",
+    "seedance_videos_response_400_error_message_4": "响应的错误信息。",
+    "seedance_videos_response_400_trace_id_4": "本次请求的追踪 ID。",
+    "seedance_videos_response_400_error_code_5": "响应的错误码。",
+    "seedance_videos_response_400_error_message_5": "响应的错误信息。",
+    "seedance_videos_response_400_trace_id_5": "本次请求的追踪 ID。",
+    "seedance_videos_response_400": "请求错误，可能是参数缺失或无效。",
+    "seedance_videos_response_401_error_code": "响应的错误码。",
+    "seedance_videos_response_401_error_message": "响应的错误信息。",
+    "seedance_videos_response_401_trace_id": "本次请求的追踪 ID。",
+    "seedance_videos_response_401_error_code_2": "响应的错误码。",
+    "seedance_videos_response_401_error_message_2": "响应的错误信息。",
+    "seedance_videos_response_401_trace_id_2": "本次请求的追踪 ID。",
+    "seedance_videos_response_401_error_code_3": "响应的错误码。",
+    "seedance_videos_response_401_error_message_3": "响应的错误信息。",
+    "seedance_videos_response_401_trace_id_3": "本次请求的追踪 ID。",
+    "seedance_videos_response_401": "未授权，授权令牌无效或缺失。",
+    "seedance_videos_response_403_error_code": "响应的错误码。",
+    "seedance_videos_response_403_error_message": "响应的错误信息。",
+    "seedance_videos_response_403_trace_id": "本次请求的追踪 ID。",
+    "seedance_videos_response_403": "未授权，授权令牌无效或缺失。",
+    "seedance_videos_response_404_error_code": "响应的错误码。",
+    "seedance_videos_response_404_error_message": "响应的错误信息。",
+    "seedance_videos_response_404_trace_id": "本次请求的追踪 ID。",
+    "seedance_videos_response_404": "未授权，授权令牌无效或缺失。",
+    "seedance_videos_response_413_error_code": "响应的错误码。",
+    "seedance_videos_response_413_error_message": "响应的错误信息。",
+    "seedance_videos_response_413_trace_id": "本次请求的追踪 ID。",
+    "seedance_videos_response_413": "未授权，授权令牌无效或缺失。",
+    "seedance_videos_response_429_error_code": "响应的错误码。",
+    "seedance_videos_response_429_error_message": "响应的错误信息。",
+    "seedance_videos_response_429_trace_id": "本次请求的追踪 ID。",
+    "seedance_videos_response_429": "请求过多，已超出速率限制。",
+    "seedance_videos_response_500_error_code": "响应的错误码。",
+    "seedance_videos_response_500_error_message": "响应的错误信息。",
+    "seedance_videos_response_500_trace_id": "本次请求的追踪 ID。",
+    "seedance_videos_response_500": "服务器内部错误，服务端发生异常。",
+    "seedance_videos_param_accept": "指定服务器响应的格式。若未指定，则默认格式为 `application/json`。",
+    "seedance_videos_model": "用于视频生成的模型 ID。Seedance 2.5 使用 `doubao-seedance-2-5-260628`。",
+    "seedance_videos": "视频生成的输入内容。每个条目必须包含与 `type` 对应的 `text`、`image_url`、`audio_url` 或 `video_url` 之一。其他字段的含义和是否必填取决于 `type` 的值。",
+    "seedance_videos_type": "内容类型判别字段。",
+    "seedance_videos_text": "描述期望生成视频的文本内容。可在提示词末尾使用旧版 `--param value` 语法附加内联参数（弱校验，无效值将静默使用默认值）。支持的内联参数：`--rs`（分辨率：480p/720p/1080p）、`--rt`（宽高比：16:9/4:3/1:1/3:4/9:16/21:9/adaptive）、`--dur`（时长，单位秒：Seedance 1.0 Pro/Pro Fast 为 2-12；Seedance 1.5 Pro 为 4-12 或 -1；Seedance 2.0 系列为 4-15 或 -1，-1 表示自动）、`--frames`（帧数：满足 25+4n 的整数，范围 [29,361]）、`--fps`（帧率：仅支持 24）、`--seed`（随机种子：-1 至 4294967295）、`--cf`（固定镜头：true/false）、`--wm`（水印：true/false）。如需强校验，请改用请求体顶层参数。",
+    "seedance_videos_type_2": "内容类型判别字段。",
+    "seedance_videos_image_url_url": "图片 URL 或 Base64 编码图片（格式：data:image/<format>;base64,<data>）。图片尺寸至少需为 300×300 像素。",
+    "seedance_videos_image_url": "图片对象。必须为包含 `url` 属性的对象，`url` 值为图片 URL 或 Base64 数据。",
+    "seedance_videos_role": "可选。图片的位置或用途。首帧（first_frame）、首尾帧（last_frame 组合）和参考图（reference_image）三种场景互斥，不可混用。",
+    "seedance_videos_type_3": "内容类型判别字段。",
+    "seedance_videos_audio_url_url": "音频 URL。Seedance 2.0 系列支持参考音频，用于生成有声视频或参考人声音色、背景音乐等音频信息。素材要求：格式为 wav 或 mp3；单条时长 2~15 秒，最多 3 条且所有音频总时长不超过 15 秒；单条不超过 15 MB。超出时长范围会在素材处理阶段失败。",
+    "seedance_videos_audio_url": "音频对象。必须为包含 `url` 属性的对象，`url` 值为公网可访问的音频 URL。",
+    "seedance_videos_audio_role": "可选。音频用途，当前支持 reference_audio。",
+    "seedance_videos_type_4": "内容类型判别字段。",
+    "seedance_videos_video_url_url": "视频 URL。Seedance 2.0 系列支持参考视频，用于参考主体内容、运镜、动作表现或整体风格。素材要求：格式为 mp4 或 mov；单条时长 2~15 秒，最多 3 条且所有视频总时长不超过 15 秒。",
+    "seedance_videos_video_url": "视频对象。必须为包含 `url` 属性的对象，`url` 值为公网可访问的视频 URL。",
+    "seedance_videos_video_role": "可选。视频用途，当前支持 reference_video。",
+    "seedance_videos_resolution": "视频分辨率。Seedance 2.5 支持 480p、720p；Seedance 2.0 Standard 支持至 4k，Fast/Mini 支持 480p、720p。其他模型能力见服务文档。",
+    "seedance_videos_ratio": "生成视频的宽高比",
+    "seedance_videos_duration": "生成视频的时长，单位为秒。Seedance 2.5 支持 4~30 秒或 -1；Seedance 2.0 系列支持 4~15 秒或 -1；-1 表示自动时长。",
+    "seedance_videos_frames": "生成视频的帧数，取值范围 [29, 289] 且必须满足 25+4n（如 29、33、37……289）。仅 Seedance 1.0 系列支持，Seedance 1.5 Pro 与 2.0 系列请改用 duration。duration 和 frames 二选一即可；若同时指定，frames 的优先级高于 duration。",
+    "seedance_videos_seed": "用于可复现生成的随机种子，取值范围为 -1 至 4294967295；-1 表示随机。",
+    "seedance_videos_camerafixed": "是否在生成过程中固定摄像机位置",
+    "seedance_videos_watermark": "是否在生成的视频上添加水印",
+    "seedance_videos_generate_audio": "是否为视频生成音频。`doubao-seedance-1-5-pro-251215` 及 `doubao-seedance-2-0` 系列模型支持此参数，其他模型将忽略该参数。",
+    "seedance_videos_callback_url": "接收任务最终结果通知的回调 URL。提供后，API 将立即返回 `task_id`，并在任务完成时向该 URL 推送结果。",
+    "seedance_videos_async": "是否以异步模式处理。设为 `true` 时接口立即返回 `task_id`，无需提供 `callback_url`，随后通过对应的任务查询接口轮询获取结果；若同时提供了 `callback_url`，结果会推送至该回调地址。",
+    "seedance_videos_return_last_frame": "是否返回生成视频的最后一帧",
+    "seedance_videos_execution_expires_after": "任务超时阈值，单位为秒",
+    "seedance_videos_servers": "Ace Data Cloud API 服务器",
+    "seedance_videos_omni_reference_task_type": "Seedance 2.5 全模态任务类型：auto 自动判断，edit 编辑参考视频，extend 延长参考视频。edit/extend 需要 reference_video 和 adaptive 比例；edit 的 duration 必须为 -1。其他模型不支持此字段。",
+    "seedance_videos_output_format": "Seedance 2.5 输出格式，可选 mp4 或 mov。其他模型仅使用其默认格式。",
+    "seedance_videos_tools": "Seedance 2.5 可选工具配置数组。仅传入文档明确支持的工具对象。"
+  }
+}

--- a/typescript/src/resources/providers/seedance.ts
+++ b/typescript/src/resources/providers/seedance.ts
@@ -17,30 +17,36 @@ function taskId(result: Record<string, unknown>): string {
 }
 
 export interface SeedanceGenerateOptions {
-  /** Model ID for video generation */
-  model: "doubao-seedance-1-0-pro-250528" | "doubao-seedance-1-0-pro-fast-251015" | "doubao-seedance-1-5-pro-251215" | "doubao-seedance-1-0-lite-t2v-250428" | "doubao-seedance-1-0-lite-i2v-250428" | "doubao-seedance-2-0-260128" | "doubao-seedance-2-0-fast-260128" | "doubao-seedance-2-0-mini-260615";
-  /** Input content for video generation. Each entry must include one of `text`, `image_url`, `audio_url`, or `video_url` corresponding to the `type`. The meaning of other fields and whether they are required depends on the value of `type`. */
+  /** $t(seedance_videos_model) */
+  model: "doubao-seedance-1-0-pro-250528" | "doubao-seedance-1-0-pro-fast-251015" | "doubao-seedance-1-5-pro-251215" | "doubao-seedance-1-0-lite-t2v-250428" | "doubao-seedance-1-0-lite-i2v-250428" | "doubao-seedance-2-0-260128" | "doubao-seedance-2-0-fast-260128" | "doubao-seedance-2-0-mini-260615" | "doubao-seedance-2-5-260628";
+  /** $t(seedance_videos) */
   content: unknown[];
-  /** The random seed used for reproducible generation has a value range from -1 to 4294967295; -1 indicates randomness. */
-  seed?: number;
-  /** Aspect ratio of the generated video */
-  ratio?: "16:9" | "4:3" | "1:1" | "3:4" | "9:16" | "21:9" | "adaptive";
-  /** The frame count for generating a video must meet 25 + 4n (such as 29, 33, 37... 361). Either duration or frames can be specified; if both are specified, frames take priority over duration. */
-  frames?: number;
-  /** The duration of the generated video, in seconds. Either duration or frames can be specified; if both are specified, frames take priority over duration. The duration range varies for each model: Seedance 2.0 series is 4 to 15 seconds or -1, Seedance 1.5 Pro is 4 to 12 seconds or -1, and Seedance 1.0 series is 2 to 12 seconds. -1 indicates automatic duration. */
-  duration?: number;
-  /** Whether to add a watermark to the generated video. */
-  watermark?: boolean;
-  /** Video resolution. The default value depends on the model used: most models default to 720p, while the lite model defaults to 480p. Note that the supported resolutions vary by model: `4k` is only supported by doubao-seedance-2-0 (standard version); doubao-seedance-2-0-fast and doubao-seedance-2-0-mini do not support 1080p and 4k. */
+  /** $t(seedance_videos_resolution) */
   resolution?: "480p" | "720p" | "1080p" | "4k";
-  /** Is the camera position fixed during the generation process? */
+  /** $t(seedance_videos_ratio) */
+  ratio?: "16:9" | "4:3" | "1:1" | "3:4" | "9:16" | "21:9" | "adaptive";
+  /** $t(seedance_videos_duration) */
+  duration?: number;
+  /** $t(seedance_videos_frames) */
+  frames?: number;
+  /** $t(seedance_videos_seed) */
+  seed?: number;
+  /** $t(seedance_videos_camerafixed) */
   camerafixed?: boolean;
-  /** Whether to generate audio from video. The `doubao-seedance-1-5-pro-251215` and `doubao-seedance-2-0` series models support this parameter, while other models will ignore this parameter. */
+  /** $t(seedance_videos_watermark) */
+  watermark?: boolean;
+  /** $t(seedance_videos_generate_audio) */
   generateAudio?: boolean;
-  /** Whether to return the last frame of the generated video. */
+  /** $t(seedance_videos_return_last_frame) */
   returnLastFrame?: boolean;
-  /** Task timeout threshold, unit in seconds */
+  /** $t(seedance_videos_execution_expires_after) */
   executionExpiresAfter?: number;
+  /** $t(seedance_videos_omni_reference_task_type) */
+  omniReferenceTaskType?: "auto" | "edit" | "extend";
+  /** $t(seedance_videos_output_format) */
+  outputFormat?: "mp4" | "mov";
+  /** $t(seedance_videos_tools) */
+  tools?: Array<Record<string, unknown>>;
   /** Submit asynchronously and poll. Defaults to true. */
   async?: boolean;
   /** Wait for completion before returning the handle. */
@@ -56,23 +62,26 @@ export interface SeedanceGenerateOptions {
 export class Seedance {
   constructor(private transport: Transport) {}
 
-  /** ByteDance Seedance video generation API. Supports doubao-seedance-1-0-pro-250528, doubao-seedance-1-0-pro-fast-251015, doubao-seedance-1-5-pro-251215, doubao-seedance-1-0-lite-t2v-250428, and doubao-s */
+  /** Call /seedance/videos. */
   async generate(options: SeedanceGenerateOptions): Promise<TaskHandle> {
     const body: Record<string, unknown> = {};
     body["model"] = options.model;
     body["content"] = options.content;
-    if (options.seed !== undefined) body["seed"] = options.seed;
-    body["ratio"] = options.ratio ?? "16:9";
-    if (options.frames !== undefined) body["frames"] = options.frames;
-    if (options.duration !== undefined) body["duration"] = options.duration;
-    if (options.watermark !== undefined) body["watermark"] = options.watermark;
     if (options.resolution !== undefined) body["resolution"] = options.resolution;
+    body["ratio"] = options.ratio ?? "16:9";
+    if (options.duration !== undefined) body["duration"] = options.duration;
+    if (options.frames !== undefined) body["frames"] = options.frames;
+    if (options.seed !== undefined) body["seed"] = options.seed;
     if (options.camerafixed !== undefined) body["camerafixed"] = options.camerafixed;
+    if (options.watermark !== undefined) body["watermark"] = options.watermark;
     body["generate_audio"] = options.generateAudio ?? false;
     body["return_last_frame"] = options.returnLastFrame ?? false;
     body["execution_expires_after"] = options.executionExpiresAfter ?? 172800;
+    if (options.omniReferenceTaskType !== undefined) body["omni_reference_task_type"] = options.omniReferenceTaskType;
+    if (options.outputFormat !== undefined) body["output_format"] = options.outputFormat;
+    if (options.tools !== undefined) body["tools"] = options.tools;
     for (const [key, value] of Object.entries(options)) {
-      if (!["async", "callbackUrl", "camerafixed", "content", "duration", "executionExpiresAfter", "frames", "generateAudio", "maxWait", "model", "pollInterval", "ratio", "resolution", "returnLastFrame", "seed", "wait", "watermark"].includes(key) && value !== undefined) {
+      if (!["async", "callbackUrl", "camerafixed", "content", "duration", "executionExpiresAfter", "frames", "generateAudio", "maxWait", "model", "omniReferenceTaskType", "outputFormat", "pollInterval", "ratio", "resolution", "returnLastFrame", "seed", "tools", "wait", "watermark"].includes(key) && value !== undefined) {
         body[key] = value;
       }
     }

--- a/typescript/tests/seedance.test.ts
+++ b/typescript/tests/seedance.test.ts
@@ -1,0 +1,41 @@
+import { Seedance } from '../src/resources/providers/seedance';
+import { TaskHandle } from '../src/runtime/tasks';
+
+describe('Seedance provider', () => {
+  it('serializes the Seedance 2.5 public contract', async () => {
+    const request = jest.fn().mockResolvedValue({ task_id: 'seedance-25' });
+    const seedance = new Seedance({ request } as any);
+    const task = await seedance.generate({
+      model: 'doubao-seedance-2-5-260628',
+      content: [{ type: 'text', text: 'Extend the scene' }],
+      duration: 30,
+      camerafixed: true,
+      omniReferenceTaskType: 'extend',
+      outputFormat: 'mov',
+      tools: [{ type: 'web_search' }],
+    });
+    expect(task).toBeInstanceOf(TaskHandle);
+    expect(request).toHaveBeenCalledWith('POST', '/seedance/videos', {
+      json: expect.objectContaining({
+        model: 'doubao-seedance-2-5-260628',
+        duration: 30,
+        camerafixed: true,
+        omni_reference_task_type: 'extend',
+        output_format: 'mov',
+        tools: [{ type: 'web_search' }],
+        async: true,
+      }),
+    });
+    expect((request.mock.calls[0][2].json as Record<string, unknown>).camera_fixed).toBeUndefined();
+  });
+
+  it('does not send Seedance 2.5 defaults to 2.0', async () => {
+    const request = jest.fn().mockResolvedValue({ task_id: 'seedance-20' });
+    const seedance = new Seedance({ request } as any);
+    await seedance.generate({
+      model: 'doubao-seedance-2-0-260128',
+      content: [{ type: 'text', text: 'A scene' }],
+    });
+    expect(request.mock.calls[0][2].json.output_format).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Dependencies

- https://github.com/AceDataCloud/PlatformService/pull/1991
- https://github.com/AceDataCloud/PlatformBackend/pull/1474

## Contract

- Refreshes the canonical Seedance OpenAPI snapshot.
- Regenerates Python, TypeScript, and Go providers with the Seedance 2.5 model, 30-second duration, task type, output format, and tools.
- Preserves the public `camerafixed` field and never emits internal `camera_fixed`.
- Omits 2.5-only fields from 2.0 requests unless callers explicitly set them.
- Keeps async task handles and polling behavior unchanged.

Provider sources were generated with `scripts/generate_providers.py`; only tests were hand-authored.

## Tests

- Python: ruff/format passed; 178 passed, 29 skipped.
- TypeScript: 61 passed, 27 skipped; package build and declarations passed.
- Go: `go test -race -count=1 ./...` passed.
- `git diff --check` and internal-field scan passed.

## Rollout / rollback

Merge after the public OpenAPI contract. Python/npm publication follows the repository release workflow; rollback by reverting and publishing the previous package versions.

## Adversarial review

Not requested; no adversarial review was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)